### PR TITLE
Replaces simple form with custom form builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Godmin is an admin engine for Rails 4+.
 	- [Redirecting](#redirecting)
 	- [Pagination](#pagination)
 - [Views](#views)
+  - [Forms](#forms)
 - [Models](#models)
 - [Authentication](#authentication)
 	- [Simple authentication](#simple-authentication)
@@ -368,11 +369,23 @@ It is easy to override view templates and partials in Godmin, both globally and 
 
 If you wish to customize the content of a table column, you can place a partial under `app/views/{resource}/columns/{column_name}.html.erb`, e.g. `app/views/articles/columns/_title.html.erb`. The resource is available to the partial through the `resource` variable.
 
-Oftentimes, the default form provided by Godmin doesn't cut it. The `godmin/resource/_form.html.erb` partial is therefore one of the most common to override per resource.
+Oftentimes, the default form provided by Godmin doesn't cut it. The `godmin/resource/_form.html.erb` partial is therefore one of the most common to override per resource. See below for more on form building.
 
 Likewise, the `godmin/shared/_navigation.html.erb` partial can be overridden to build a custom navigation bar.
 
 The full list of templates and partials that can be overridden [can be found here](https://github.com/varvet/godmin/tree/master/app/views/godmin)
+
+### Forms
+
+Godmin comes with its own FormBuilder that automatically generates bootstrapped markup. It is based on the [Rails Bootstrap Forms](https://github.com/bootstrap-ruby/rails-bootstrap-forms) FormBuilder, and all its methods are directly available. In addition it has a few convenience methods that can be leveraged.
+
+The `input` method will automatically detect the type of field from the database and generate an appropriate form field:
+
+```ruby
+form_for @resource do |f|
+  f.input :attribute
+end
+```
 
 ## Models
 

--- a/app/views/godmin/resource/_form.html.erb
+++ b/app/views/godmin/resource/_form.html.erb
@@ -1,12 +1,10 @@
-<%= simple_form_for @resource, html: { role: "form" } do |f| %>
-  <% attrs_for_form.each do |attr| %>
-    <div class="form-group">
-      <% if @resource_class.reflect_on_association(attr) %>
-        <%= f.association attr, error: false, input_html: { class: "form-control", data: { behavior: "select-box" } } %>
-      <% else %>
-        <%= f.input attr, error: false, input_html: { class: "form-control" } %>
-      <% end %>
-    </div>
+<%= form_for @resource do |f| %>
+  <% attrs_for_form.each do |attribute| %>
+    <% if f.object.class.reflect_on_association(attribute) %>
+      <%= f.association attribute %>
+    <% else %>
+      <%= f.input attribute %>
+    <% end %>
   <% end %>
-  <%= f.button :submit, class: "btn btn-default" %>
+  <%= f.submit %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,3 +33,6 @@ en:
       entries:
         zero: "No %{resource} found"
         other: "Showing %{count} out of %{total} %{resource}"
+    datetimepickers:
+      date: ! "%m/%d/%Y"
+      datetime: ! "%m/%d/%Y%l:%M %p"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,5 +34,5 @@ en:
         zero: "No %{resource} found"
         other: "Showing %{count} out of %{total} %{resource}"
     datetimepickers:
-      date: ! "%m/%d/%Y"
-      datetime: ! "%m/%d/%Y%l:%M %p"
+      datepicker: ! "%m/%d/%Y"
+      datetimepicker: ! "%m/%d/%Y%l:%M %p"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -34,5 +34,5 @@ sv:
         zero: "Inga %{resource} funna"
         other: "Visar %{count} av %{total} %{resource}"
     datetimepickers:
-      date: ! "%Y-%m-%d"
-      datetime: ! "%Y-%m-%d %H:%M"
+      datepicker: ! "%Y-%m-%d"
+      datetimepicker: ! "%Y-%m-%d %H:%M"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -33,3 +33,6 @@ sv:
       entries:
         zero: "Inga %{resource} funna"
         other: "Visar %{count} av %{total} %{resource}"
+    datetimepickers:
+      date: ! "%Y-%m-%d"
+      datetime: ! "%Y-%m-%d %H:%M"

--- a/godmin.gemspec
+++ b/godmin.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "bcrypt", "~> 3.1.7"
   gem.add_dependency "bootstrap-sass", "~> 3.3.1.0"
+  gem.add_dependency "bootstrap_form", "~> 2.2.0"
   gem.add_dependency "coffee-rails", [">= 4.0", "< 4.2"]
   gem.add_dependency "momentjs-rails", ">= 2.8.1"
   gem.add_dependency "rails", [">= 4.0", "< 4.2"]
   gem.add_dependency "sass-rails", [">= 4.0", "< 4.2"]
   gem.add_dependency "selectize-rails", "~> 0.11.2"
-  gem.add_dependency "simple_form", "~> 3.0.0"
 
   gem.add_development_dependency "sqlite3"
 end

--- a/lib/godmin.rb
+++ b/lib/godmin.rb
@@ -1,7 +1,7 @@
 require "bootstrap-sass"
+require "bootstrap_form"
 require "momentjs-rails"
 require "selectize-rails"
-require "simple_form"
 require "godmin/application"
 require "godmin/authentication"
 require "godmin/authorization"

--- a/lib/godmin/helpers/forms.rb
+++ b/lib/godmin/helpers/forms.rb
@@ -16,9 +16,9 @@ module Godmin
         when :boolean
           check_box(attribute, options)
         when :date
-          text_field(attribute, value: datetime_value(attribute, :datepicker), data: { behavior: "datepicker" })
+          date_field(attribute, options)
         when :datetime
-          text_field(attribute, value: datetime_value(attribute, :datetimepicker), data: { behavior: "datetimepicker" })
+          datetime_field(attribute, options)
         else
           text_field(attribute, options)
         end
@@ -31,6 +31,14 @@ module Godmin
         else
           input(attribute, options)
         end
+      end
+
+      def date_field(attribute, options = {})
+        text_field(attribute, value: datetime_value(attribute, :datepicker), data: { behavior: "datepicker" })
+      end
+
+      def datetime_field(attribute, options = {})
+        text_field(attribute, value: datetime_value(attribute, :datetimepicker), data: { behavior: "datetimepicker" })
       end
 
       private

--- a/lib/godmin/helpers/forms.rb
+++ b/lib/godmin/helpers/forms.rb
@@ -2,7 +2,7 @@ module Godmin
   module Helpers
     module Forms
       def form_for(record, options = {}, &block)
-        super(record, { builder: FormBuilders::FormBuilder }.merge(options), &block)
+        super(record, { builder: FormBuilders::FormBuilder, inline_errors: false }.merge(options), &block)
       end
     end
   end

--- a/lib/godmin/helpers/forms.rb
+++ b/lib/godmin/helpers/forms.rb
@@ -16,9 +16,9 @@ module Godmin
         when :boolean
           check_box(attribute, options)
         when :date
-          text_field(attribute, value: localized_datetime(attribute, :date), data: { behavior: "datepicker" })
+          text_field(attribute, value: datetime_value(attribute, :datepicker), data: { behavior: "datepicker" })
         when :datetime
-          text_field(attribute, value: localized_datetime(attribute, :datetime), data: { behavior: "datetimepicker" })
+          text_field(attribute, value: datetime_value(attribute, :datetimepicker), data: { behavior: "datetimepicker" })
         else
           text_field(attribute, options)
         end
@@ -51,7 +51,7 @@ module Godmin
         @object.class.reflect_on_association(attribute)
       end
 
-      def localized_datetime(attribute, format)
+      def datetime_value(attribute, format)
         object.send(attribute).try(:strftime, @template.translate_scoped("datetimepickers.#{format}"))
       end
     end

--- a/lib/godmin/helpers/forms.rb
+++ b/lib/godmin/helpers/forms.rb
@@ -60,7 +60,7 @@ module Godmin
       end
 
       def datetime_value(attribute, format)
-        object.send(attribute).try(:strftime, @template.translate_scoped("datetimepickers.#{format}"))
+        @object.send(attribute).try(:strftime, @template.translate_scoped("datetimepickers.#{format}"))
       end
     end
   end


### PR DESCRIPTION
This PR replaces SimpleForm with a custom form builder that inherits from a bootstrap form builder. That way we get bootstrap markup out of the box without having to worry about #24 

Fixes #24 

In terms of associations it only supports `belongs_to` as of now. If we need more we should add it later.

- [x] Remove SimpleForm
- [x] Create custom FormBuilder
- [x] Deal with form errors
- [x] Extract datepicker methods, in case you don't want to use `input`