### PR TITLE
Rails 4.2 compatibility

### DIFF
--- a/godmin.gemspec
+++ b/godmin.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "bootstrap-sass", "~> 3.3.1.0"
   gem.add_dependency "coffee-rails", [">= 4.0", "< 4.2"]
   gem.add_dependency "momentjs-rails", ">= 2.8.1"
-  gem.add_dependency "rails", [">= 4.0", "< 4.2"]
-  gem.add_dependency "sass-rails", [">= 4.0", "< 4.2"]
+  gem.add_dependency "rails", "~> 4.0"
+  gem.add_dependency "sass-rails", ">= 4.0"
   gem.add_dependency "selectize-rails", "~> 0.11.2"
   gem.add_dependency "simple_form", "~> 3.0.0"
 

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -31,6 +31,9 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Randomize the order test cases are executed.
+  config.active_support.test_order = :random
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 end


### PR DESCRIPTION
Fixes #34 and #49.

Tested with a fresh install of a Rails 4.2.0 app as a "standalone installation". Generated one resource and played around a bit and it seems to be working just fine.

I have not updated the dummy test app. It seems to be unused anyway...