### PR TITLE
Prepend view paths to make our override the Rails default

### DIFF
--- a/lib/godmin/application.rb
+++ b/lib/godmin/application.rb
@@ -16,7 +16,7 @@ module Godmin
       helper_method :authentication_enabled?
       helper_method :authorization_enabled?
 
-      before_action :append_view_paths
+      before_action :prepend_view_paths
 
       layout "godmin/application"
     end
@@ -25,9 +25,9 @@ module Godmin
 
     private
 
-    def append_view_paths
-      append_view_path Godmin::EngineResolver.new(controller_name)
-      append_view_path Godmin::GodminResolver.new(controller_name)
+    def prepend_view_paths
+      prepend_view_path Godmin::GodminResolver.new(controller_name)
+      prepend_view_path Godmin::EngineResolver.new(controller_name)
     end
 
     def authentication_enabled?


### PR DESCRIPTION
Fixes #39

We should prepend our resolvers in the view path to make sure they are being used before the Rails default stuff.