### PR TITLE
Added count for each scope in the scope tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.10.0 - Unreleased
 Features
+- Shows the number of items in each scope in the scope tab (https://github.com/varvet/godmin/issues/16)
 - Two new overridable methods for resources: `build_resource` and `find_resource`
 
 Bug fixes

--- a/app/views/godmin/resource/_scopes.html.erb
+++ b/app/views/godmin/resource/_scopes.html.erb
@@ -3,7 +3,7 @@
     <ul class="nav nav-tabs">
       <% scope_map.each do |name, options| %>
         <li class="<%= "active" if params[:scope] == name.to_s %>">
-          <%= link_to translate_scoped("scopes.#{name.to_s.underscore}", default: name.to_s.titleize), url_for(params.merge(scope: name, only_path: true).except(:page)) %>
+          <%= link_to translate_scoped("scopes.#{name.to_s.underscore}", default: name.to_s.titleize) + " (#{scope_count(name)})", url_for(params.merge(scope: name, only_path: true).except(:page)) %>
         </li>
       <% end %>
     </ul>

--- a/app/views/godmin/resource/_scopes.html.erb
+++ b/app/views/godmin/resource/_scopes.html.erb
@@ -3,7 +3,10 @@
     <ul class="nav nav-tabs">
       <% scope_map.each do |name, options| %>
         <li class="<%= "active" if params[:scope] == name.to_s %>">
-          <%= link_to translate_scoped("scopes.#{name.to_s.underscore}", default: name.to_s.titleize) + " (#{scope_count(name)})", url_for(params.merge(scope: name, only_path: true).except(:page)) %>
+          <%= link_to url_for(params.merge(scope: name, only_path: true).except(:page)) do %>
+            <%= translate_scoped("scopes.#{name.to_s.underscore}", default: name.to_s.titleize) %>
+            <span class="text-muted"> (<%= scope_count(name) %>)</span>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/lib/godmin/resource/pagination.rb
+++ b/lib/godmin/resource/pagination.rb
@@ -31,25 +31,27 @@ module Godmin
       end
 
       def pages
-        pages = (1..total_pages).to_a
+        @pages ||= begin
+          pages = (1..total_pages).to_a
 
-        return pages unless total_pages > WINDOW_SIZE
+          return pages unless total_pages > WINDOW_SIZE
 
-        if current_page < WINDOW_SIZE
-          pages.slice(0, WINDOW_SIZE)
-        elsif current_page > (total_pages - WINDOW_SIZE)
-          pages.slice(-WINDOW_SIZE, WINDOW_SIZE)
-        else
-          pages.slice(pages.index(current_page) - (WINDOW_SIZE / 2), WINDOW_SIZE)
+          if current_page < WINDOW_SIZE
+            pages.slice(0, WINDOW_SIZE)
+          elsif current_page > (total_pages - WINDOW_SIZE)
+            pages.slice(-WINDOW_SIZE, WINDOW_SIZE)
+          else
+            pages.slice(pages.index(current_page) - (WINDOW_SIZE / 2), WINDOW_SIZE)
+          end
         end
       end
 
       def total_pages
-        (total_resources.to_f / self.class.per_page).ceil
+        @total_pages ||= (total_resources.to_f / self.class.per_page).ceil
       end
 
       def total_resources
-        resources.limit(nil).offset(nil).count
+        @total_resource ||= resources.limit(nil).offset(nil).count
       end
 
       module ClassMethods

--- a/lib/godmin/resource/scopes.rb
+++ b/lib/godmin/resource/scopes.rb
@@ -27,7 +27,7 @@ module Godmin
       def scope_count(scope)
         apply_filters(
           send("scope_#{scope}", resources_relation)
-        ).limit(nil).offset(nil).count
+        ).count
       end
 
       def default_scope

--- a/lib/godmin/resource/scopes.rb
+++ b/lib/godmin/resource/scopes.rb
@@ -5,6 +5,7 @@ module Godmin
 
       included do
         helper_method :scope_map
+        helper_method :scope_count
       end
 
       def scope_map
@@ -12,9 +13,7 @@ module Godmin
       end
 
       def apply_scope(resources)
-        if params[:scope].blank?
-          params[:scope] = default_scope
-        end
+        params[:scope] = default_scope if params[:scope].blank?
 
         if params[:scope] && scope_map.key?(params[:scope].to_sym)
           send("scope_#{params[:scope]}", resources)
@@ -24,6 +23,10 @@ module Godmin
       end
 
       protected
+
+      def scope_count(scope)
+        send("scope_#{scope}", resources).limit(nil).offset(nil).count
+      end
 
       def default_scope
         scope = scope_map.find -> { scope_map.first } do |_key, value|

--- a/lib/godmin/resource/scopes.rb
+++ b/lib/godmin/resource/scopes.rb
@@ -12,6 +12,12 @@ module Godmin
         self.class.scope_map
       end
 
+      def scope_count(scope)
+        apply_filters(
+          send("scope_#{scope}", resources_relation)
+        ).count
+      end
+
       def apply_scope(resources)
         params[:scope] = default_scope if params[:scope].blank?
 
@@ -23,12 +29,6 @@ module Godmin
       end
 
       protected
-
-      def scope_count(scope)
-        apply_filters(
-          send("scope_#{scope}", resources_relation)
-        ).count
-      end
 
       def default_scope
         scope = scope_map.find -> { scope_map.first } do |_key, value|

--- a/lib/godmin/resource/scopes.rb
+++ b/lib/godmin/resource/scopes.rb
@@ -25,7 +25,9 @@ module Godmin
       protected
 
       def scope_count(scope)
-        send("scope_#{scope}", resources).limit(nil).offset(nil).count
+        apply_filters(
+          send("scope_#{scope}", resources_relation)
+        ).limit(nil).offset(nil).count
       end
 
       def default_scope


### PR DESCRIPTION
Fixes #16 

It makes one count DB call for each scope. I guess that is OK since count is pretty quick and you probably don't have that many scopes.

It takes filters in consideration but removes any limit and offset to avoid the pagination.

It looks like this:

![skarmavbild 2015-02-02 kl 16 34 39](https://cloud.githubusercontent.com/assets/379823/6003144/782f6fd6-aaf9-11e4-91f2-db1df8ced4aa.png)
