### PR TITLE
Batch action refactor

### DIFF
--- a/app/assets/javascripts/godmin/batch-actions.js
+++ b/app/assets/javascripts/godmin/batch-actions.js
@@ -54,6 +54,13 @@ Godmin.BatchActions = (function() {
 
   function triggerAction() {
     $form.find('[data-behavior~=batch-actions-action]').val($(this).data('value'));
+
+    var ids = $form.find('[data-behavior~=batch-actions-checkbox]:checked').map(function() {
+      return this.id;
+    }).toArray().join(',');
+
+    $form.attr('action', $form.attr('action') + '/' + ids);
+
     $form.submit();
   }
 

--- a/app/assets/javascripts/godmin/batch-actions.js
+++ b/app/assets/javascripts/godmin/batch-actions.js
@@ -56,7 +56,7 @@ Godmin.BatchActions = (function() {
     $form.find('[data-behavior~=batch-actions-action]').val($(this).data('value'));
 
     var ids = $form.find('[data-behavior~=batch-actions-checkbox]:checked').map(function() {
-      return this.id;
+      return this.id.match(/\d+/);
     }).toArray().join(',');
 
     $form.attr('action', $form.attr('action') + '/' + ids);

--- a/app/assets/javascripts/godmin/batch-actions.js
+++ b/app/assets/javascripts/godmin/batch-actions.js
@@ -32,8 +32,14 @@ Godmin.BatchActions = (function() {
     $selectNone.removeClass('hidden');
   }
 
+  function checkedCheckboxes() {
+    return $form.find('[data-behavior~=batch-actions-checkbox]:checked').map(function() {
+      return this.id.match(/\d+/);
+    }).toArray().join(',');
+  }
+
   function toggleCheckboxes() {
-    if ($form.find('[data-behavior~=batch-actions-checkbox]:checked').length > 0) {
+    if (checkedCheckboxes().length > 0) {
       $form.find('[data-behavior~=batch-actions-checkbox]').prop('checked', false).trigger('change');
       setSelectToAll();
     } else {
@@ -43,7 +49,7 @@ Godmin.BatchActions = (function() {
   }
 
   function toggleActions() {
-    if ($form.find('[data-behavior~=batch-actions-checkbox]:checked').length) {
+    if (checkedCheckboxes().length) {
       $('[data-behavior~=batch-actions-action-link]').removeClass('hidden');
       setSelectToNone();
     } else {
@@ -53,15 +59,10 @@ Godmin.BatchActions = (function() {
   }
 
   function triggerAction() {
-    $form.find('[data-behavior~=batch-actions-action]').val($(this).data('value'));
-
-    var ids = $form.find('[data-behavior~=batch-actions-checkbox]:checked').map(function() {
-      return this.id.match(/\d+/);
-    }).toArray().join(',');
-
-    $form.attr('action', $form.attr('action') + '/' + ids);
-
-    $form.submit();
+    $form.find('[data-behavior~=batch-actions-action]').val(
+      $(this).data('value')
+    );
+    $form.attr('action', $form.attr('action') + '/' + checkedCheckboxes()).submit();
   }
 
   return {

--- a/app/views/godmin/resource/_table.html.erb
+++ b/app/views/godmin/resource/_table.html.erb
@@ -19,7 +19,7 @@
       <% end %>
         <% if batch_action_map.present? %>
           <td align="center">
-            <%= check_box_tag "batch_action[items][#{resource.id}]", nil, nil,
+            <%= check_box_tag resource.id, nil, nil,
               data: { behavior: "batch-actions-checkbox" } %>
           </td>
         <% end %>

--- a/app/views/godmin/resource/_table.html.erb
+++ b/app/views/godmin/resource/_table.html.erb
@@ -19,7 +19,7 @@
       <% end %>
         <% if batch_action_map.present? %>
           <td align="center">
-            <%= check_box_tag resource.id, nil, nil,
+            <%= check_box_tag "batch_action[items][#{resource.id}]", nil, nil,
               data: { behavior: "batch-actions-checkbox" } %>
           </td>
         <% end %>

--- a/app/views/godmin/resource/index.html.erb
+++ b/app/views/godmin/resource/index.html.erb
@@ -6,7 +6,7 @@
   <%= render partial: "filters" %>
 <% end %>
 
-<%= form_tag [:batch_action, @resource_class], data: { behavior: "batch-actions-form" } do %>
+<%= form_tag @resource_class, method: :put, data: { behavior: "batch-actions-form" } do %>
 
   <%= render partial: "actions" %>
 

--- a/lib/godmin/rails.rb
+++ b/lib/godmin/rails.rb
@@ -18,12 +18,13 @@ module ActionDispatch::Routing
           Godmin.resources << resources.first
         end
 
-        super(*resources) do
-          if block_given?
-            yield
-          end
-          post "batch_action", on: :collection
-        end
+        super
+        # super(*resources) do
+        #   if block_given?
+        #     yield
+        #   end
+        #   # post "batch_action", on: :collection
+        # end
       end
 
       yield

--- a/lib/godmin/rails.rb
+++ b/lib/godmin/rails.rb
@@ -19,12 +19,6 @@ module ActionDispatch::Routing
         end
 
         super
-        # super(*resources) do
-        #   if block_given?
-        #     yield
-        #   end
-        #   # post "batch_action", on: :collection
-        # end
       end
 
       yield

--- a/lib/godmin/resource/batch_actions.rb
+++ b/lib/godmin/resource/batch_actions.rb
@@ -11,17 +11,41 @@ module Godmin
         self.class.batch_action_map
       end
 
-      def batch_action
-        action   = params[:batch_action][:action]
-        item_ids = params[:batch_action][:items].keys.map(&:to_i)
+      # def batch_action
+      #   action   = params[:batch_action][:action]
+      #   item_ids = params[:batch_action][:items].keys.map(&:to_i)
+      #
+      #   if batch_action_map.key?(action.to_sym)
+      #     # Store the batched item ids so they can be highlighted later
+      #     flash[:batch_actioned_ids] = item_ids
+      #
+      #     # If the batch action returns false, it is because it has implemented
+      #     # its own redirect. Therefore we return wihout redirecting.
+      #     return unless send("batch_action_#{action}", resource_class.find(item_ids))
+      #   end
+      #
+      #   redirect_to :back
+      # end
 
-        if batch_action_map.key?(action.to_sym)
-          # Store the batched item ids so they can be highlighted later
+      def update
+        if params[:id].include?(",")
+          batch_action
+        else
+          super
+        end
+      end
+
+      private
+
+      def batch_action
+        item_ids = params[:id].split(",").map(&:to_i)
+
+        if batch_action_map.key?(params[:batch_action][:action].to_sym)
           flash[:batch_actioned_ids] = item_ids
 
           # If the batch action returns false, it is because it has implemented
           # its own redirect. Therefore we return wihout redirecting.
-          return unless send("batch_action_#{action}", resource_class.find(item_ids))
+          return unless send("batch_action_#{params[:batch_action][:action]}", resource_class.find(item_ids))
         end
 
         redirect_to :back

--- a/lib/godmin/resource/batch_actions.rb
+++ b/lib/godmin/resource/batch_actions.rb
@@ -11,39 +11,21 @@ module Godmin
         self.class.batch_action_map
       end
 
-      # def batch_action
-      #   action   = params[:batch_action][:action]
-      #   item_ids = params[:batch_action][:items].keys.map(&:to_i)
-      #
-      #   if batch_action_map.key?(action.to_sym)
-      #     # Store the batched item ids so they can be highlighted later
-      #     flash[:batch_actioned_ids] = item_ids
-      #
-      #     # If the batch action returns false, it is because it has implemented
-      #     # its own redirect. Therefore we return wihout redirecting.
-      #     return unless send("batch_action_#{action}", resource_class.find(item_ids))
-      #   end
-      #
-      #   redirect_to :back
-      # end
-
       def update
-        if params[:id].include?(",")
-          item_ids = params[:id].split(",").map(&:to_i)
+        return super unless params[:id].include?(",")
 
-          if batch_action_map.key?(params[:batch_action][:action].to_sym)
-            # Store the batched item ids so they can be highlighted later
-            flash[:batch_actioned_ids] = item_ids
+        item_ids = params[:id].split(",").map(&:to_i)
 
-            # If the batch action returns false, it is because it has implemented
-            # its own redirect. Therefore we return wihout redirecting.
-            return unless send("batch_action_#{params[:batch_action][:action]}", resource_class.find(item_ids))
-          end
+        if batch_action_map.key?(params[:batch_action][:action].to_sym)
+          # Store the batched item ids so they can be highlighted later
+          flash[:batch_actioned_ids] = item_ids
 
-          redirect_to :back
-        else
-          super
+          # If the batch action returns false, it is because it has implemented
+          # its own redirect. Therefore we return wihout redirecting.
+          return unless send("batch_action_#{params[:batch_action][:action]}", resource_class.find(item_ids))
         end
+
+        redirect_to :back
       end
 
       module ClassMethods

--- a/lib/godmin/resource/batch_actions.rb
+++ b/lib/godmin/resource/batch_actions.rb
@@ -12,9 +12,9 @@ module Godmin
       end
 
       def update
-        return super unless params[:id].include?(",")
+        return super unless params[:batch_action].present? # params[:id].include?(",")
 
-        item_ids = params[:id].split(",").map(&:to_i)
+        item_ids = params[:batch_action][:items].keys.map(&:to_i)
 
         if batch_action_map.key?(params[:batch_action][:action].to_sym)
           # Store the batched item ids so they can be highlighted later

--- a/lib/godmin/resource/batch_actions.rb
+++ b/lib/godmin/resource/batch_actions.rb
@@ -29,26 +29,21 @@ module Godmin
 
       def update
         if params[:id].include?(",")
-          batch_action
+          item_ids = params[:id].split(",").map(&:to_i)
+
+          if batch_action_map.key?(params[:batch_action][:action].to_sym)
+            # Store the batched item ids so they can be highlighted later
+            flash[:batch_actioned_ids] = item_ids
+
+            # If the batch action returns false, it is because it has implemented
+            # its own redirect. Therefore we return wihout redirecting.
+            return unless send("batch_action_#{params[:batch_action][:action]}", resource_class.find(item_ids))
+          end
+
+          redirect_to :back
         else
           super
         end
-      end
-
-      private
-
-      def batch_action
-        item_ids = params[:id].split(",").map(&:to_i)
-
-        if batch_action_map.key?(params[:batch_action][:action].to_sym)
-          flash[:batch_actioned_ids] = item_ids
-
-          # If the batch action returns false, it is because it has implemented
-          # its own redirect. Therefore we return wihout redirecting.
-          return unless send("batch_action_#{params[:batch_action][:action]}", resource_class.find(item_ids))
-        end
-
-        redirect_to :back
       end
 
       module ClassMethods


### PR DESCRIPTION
- [x] Use jsonapi.org style ids instead of own action
- [ ] Add authorization
- [ ] Must form url be reset?
- [ ] What about overriding update? How much would that complicate?

Think about how to send the checkbox values, perhaps they should still have a name, and not only an id?

Could we instead do a batch action controller or something?