### PR TITLE
Use url_for to avoid router stuff when clearing filters

### DIFF
--- a/app/views/godmin/resource/_filters.html.erb
+++ b/app/views/godmin/resource/_filters.html.erb
@@ -16,7 +16,7 @@
         <div class="pull-right">
           <label>&nbsp;</label><br>
           <%= button_tag translate_scoped("filters.buttons.apply"), class: "btn btn-default" %>
-          <%= link_to translate_scoped("filters.buttons.clear"), polymorphic_path(@resource_class, scope: params[:scope], order: params[:order]), class: "btn btn-default" %>
+          <%= link_to translate_scoped("filters.buttons.clear"), url_for(params.slice(:scope, :order)), class: "btn btn-default" %>
         </div>
 
       <% end %>


### PR DESCRIPTION
What do you think about this?

The issue I had was that I had a nested route, so the polymorphic generated path did not exist.

This just clears the params and uses current url instead.

It seems to have one implication. It keeps the `scope` and `order` even if they are empty strings. `polymorphic_path` seems to ignore them if they are empty.