### PR TITLE
Override policy class in model instead of controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,12 +631,10 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-Policies are located based on the name of the controller. If you wish to specify what policy to use manually, override the following method in the controller:
+If you wish to specify what policy to use manually, override the following method in your model. It does not have to be an ActiveRecord object, but any object will do.
 
 ```ruby
-class ArticlesController < ApplicationController
-  include Godmin::Resources::ResourceController
-
+class Article
   def policy_class(_record)
     FooArticlePolicy
   end

--- a/lib/godmin/authorization.rb
+++ b/lib/godmin/authorization.rb
@@ -21,12 +21,8 @@ module Godmin
       end
     end
 
-    def policy_class(record)
-      PolicyFinder.find(record).constantize
-    end
-
     def policy(record)
-      policies[record] ||= policy_class(record).new(admin_user, record)
+      policies[record] ||= PolicyFinder.find(record).new(admin_user, record)
     end
 
     def policies

--- a/lib/godmin/authorization/policy_finder.rb
+++ b/lib/godmin/authorization/policy_finder.rb
@@ -3,6 +3,8 @@ module Godmin
     class PolicyFinder
       class << self
         def find(object)
+          return object.policy_class if object.respond_to?(:policy_class)
+          return object.class.policy_class if object.class.respond_to?(:policy_class)
           klass =
             if object.respond_to?(:model_name)
               object.model_name
@@ -20,7 +22,7 @@ module Godmin
             "#{Godmin.namespace.classify}::#{klass}Policy"
           else
             "#{klass}Policy"
-          end
+          end.constantize
         end
       end
     end

--- a/test/lib/godmin/policy_finder_test.rb
+++ b/test/lib/godmin/policy_finder_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 
-module Namespace; end
-class Namespace::ArticlePolicy; end
-class Namespace::ObjectPolicy; end
-class Article; extend ActiveModel::Naming; end
-class Overridden
+module Namespace
+  class ArticlePolicyTestPolicy; end
+  class ObjectPolicy; end
+end
+
+class ArticlePolicyTest; extend ActiveModel::Naming; end
+class OverriddenPolicyTest
   extend ActiveModel::Naming
   def self.policy_class
     Namespace::ObjectPolicy
@@ -20,8 +22,8 @@ module Godmin
     class PolicyFinderTest < ActiveSupport::TestCase
       def test_find_by_model
         namespaced_as "namespace" do
-          policy = PolicyFinder.find(Article)
-          assert_equal Namespace::ArticlePolicy, policy
+          policy = PolicyFinder.find(ArticlePolicyTest)
+          assert_equal Namespace::ArticlePolicyTestPolicy, policy
         end
       end
 
@@ -34,21 +36,21 @@ module Godmin
 
       def test_find_by_symbol
         namespaced_as "namespace" do
-          policy = PolicyFinder.find(:article)
-          assert_equal Namespace::ArticlePolicy, policy
+          policy = PolicyFinder.find(:article_policy_test)
+          assert_equal Namespace::ArticlePolicyTestPolicy, policy
         end
       end
 
       def test_override_policy_class_on_class
         namespaced_as "namespace" do
-          policy = PolicyFinder.find(Overridden)
+          policy = PolicyFinder.find(OverriddenPolicyTest)
           assert_equal Namespace::ObjectPolicy, policy
         end
       end
 
       def test_override_policy_class_on_instance
         namespaced_as "namespace" do
-          policy = PolicyFinder.find(Overridden.new)
+          policy = PolicyFinder.find(OverriddenPolicyTest.new)
           assert_equal Namespace::ObjectPolicy, policy
         end
       end

--- a/test/lib/godmin/policy_finder_test.rb
+++ b/test/lib/godmin/policy_finder_test.rb
@@ -1,6 +1,19 @@
 require "test_helper"
 
+module Namespace; end
+class Namespace::ArticlePolicy; end
+class Namespace::ObjectPolicy; end
 class Article; extend ActiveModel::Naming; end
+class Overridden
+  extend ActiveModel::Naming
+  def self.policy_class
+    Namespace::ObjectPolicy
+  end
+
+  def policy_class
+    Namespace::ObjectPolicy
+  end
+end
 
 module Godmin
   module Authorization
@@ -8,21 +21,35 @@ module Godmin
       def test_find_by_model
         namespaced_as "namespace" do
           policy = PolicyFinder.find(Article)
-          assert_equal "Namespace::ArticlePolicy", policy
+          assert_equal Namespace::ArticlePolicy, policy
         end
       end
 
       def test_find_by_class
         namespaced_as "namespace" do
           policy = PolicyFinder.find(Object)
-          assert_equal "Namespace::ObjectPolicy", policy
+          assert_equal Namespace::ObjectPolicy, policy
         end
       end
 
       def test_find_by_symbol
         namespaced_as "namespace" do
           policy = PolicyFinder.find(:article)
-          assert_equal "Namespace::ArticlePolicy", policy
+          assert_equal Namespace::ArticlePolicy, policy
+        end
+      end
+
+      def test_override_policy_class_on_class
+        namespaced_as "namespace" do
+          policy = PolicyFinder.find(Overridden)
+          assert_equal Namespace::ObjectPolicy, policy
+        end
+      end
+
+      def test_override_policy_class_on_instance
+        namespaced_as "namespace" do
+          policy = PolicyFinder.find(Overridden.new)
+          assert_equal Namespace::ObjectPolicy, policy
         end
       end
     end


### PR DESCRIPTION
Moves the policy class override to the model instead of the controller.