### PR TITLE
Allow users to specify a custom add text as data attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features
 - Adds query param to authorize
 - Adds authorization to batch actions (https://github.com/varvet/godmin/issues/33)
 - Adds show page (https://github.com/varvet/godmin/issues/77)
+- Adds option to change add text on dropdowns (https://github.com/varvet/godmin/pull/106)
 
 Bug fixes
 - Fixes a regression where filter labels were not translated

--- a/README.md
+++ b/README.md
@@ -788,6 +788,13 @@ f.select :authors, Author.all, {}, data: { behavior: "select-box" }
 f.text_field :tag_list, data: { behavior: "select-box" }
 ```
 
+If you want to change the text that appears when an option does not exist and will be created, set the data attribute `data-add-label`.
+
+```ruby
+f.text_field :tag_list, data: { behavior: "select-box", add_label: "Create:" }
+#=> Create: foobar...
+```
+
 If the field is added post page render, it can be initialized manually:
 
 ```js

--- a/app/assets/javascripts/godmin/select-boxes.js
+++ b/app/assets/javascripts/godmin/select-boxes.js
@@ -14,7 +14,12 @@ Godmin.SelectBoxes = (function() {
 
   function initializeSelectBox($el, options) {
     var defaults = {
-      inputClass: 'selectize-input'
+      inputClass: 'selectize-input',
+      render: {
+        option_create: function(data, escape) {
+          return '<div class="create">' + (this.$input.data("add-text") || "Add") + ' <strong>' + escape(data.input) + '</strong>&hellip;</div>';
+        }
+      }
     };
 
     $el.selectize($.extend(defaults, options));

--- a/app/assets/javascripts/godmin/select-boxes.js
+++ b/app/assets/javascripts/godmin/select-boxes.js
@@ -17,7 +17,7 @@ Godmin.SelectBoxes = (function() {
       inputClass: 'selectize-input',
       render: {
         option_create: function(data, escape) {
-          return '<div class="create">' + (this.$input.data("add-text") || "Add") + ' <strong>' + escape(data.input) + '</strong>&hellip;</div>';
+          return '<div class="create">' + (this.$input.data("add-label") || "+") + ' <strong>' + escape(data.input) + '</strong>&hellip;</div>';
         }
       }
     };


### PR DESCRIPTION
When using the godmin select box (Selectize) and the option does not exist it says "Add foobar...". It would be nice to be able to change this text.

This PR makes it possible to add a data attribute, `add-label` where you can set the text.

Example:
```ruby
<%= f.text_field :tag_list, data: { behavior: "select-box", add_label: "Create:" } %>
```
Looks like this:
![skarmavbild 2015-05-08 kl 10 39 24](https://cloud.githubusercontent.com/assets/379823/7533087/99266248-f56e-11e4-9c45-02a7700ceb4c.png)

It defaults to "+ foobar..." to avoid localization issues