### PR TITLE
[WIP] Datepicker format issue fix for US locale

### DIFF
--- a/app/assets/javascripts/godmin/datetimepickers.js
+++ b/app/assets/javascripts/godmin/datetimepickers.js
@@ -6,7 +6,17 @@ Godmin.Datetimepickers = (function() {
     initializeState();
   }
 
-  function initializeEvents() {}
+  function initializeEvents() {
+    $('form').on('dp.change', function(e) {
+      $(e.target).attr('data-timestamp', e.date.format());
+    });
+
+    $('form').on('submit', function() {
+      $('[data-timestamp]').each(function() {
+        $(this).val($(this).attr('data-timestamp'));
+      });
+    });
+  }
 
   function initializeState() {
     initializeDatepicker($('[data-behavior~=datepicker]'));

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,4 +41,4 @@ en:
         other: "Showing %{count} out of %{total} %{resource}"
     datetimepickers:
       datepicker: ! "%m/%d/%Y"
-      datetimepicker: ! "%m/%d/%Y%l:%M %p"
+      datetimepicker: ! "%m/%d/%Y %l:%M %p"

--- a/lib/godmin/helpers/forms.rb
+++ b/lib/godmin/helpers/forms.rb
@@ -36,14 +36,20 @@ module Godmin
       def date_field(attribute, options = {})
         text_field(attribute, options.deep_merge(
           value: datetime_value(attribute, options, :datepicker),
-          data: { behavior: "datepicker" }
+          data: {
+            behavior: "datepicker",
+            timestamp: datetime_timestamp(attribute, options)
+          }
         ))
       end
 
       def datetime_field(attribute, options = {})
         text_field(attribute, options.deep_merge(
           value: datetime_value(attribute, options, :datetimepicker),
-          data: { behavior: "datetimepicker" }
+          data: {
+            behavior: "datetimepicker",
+            timestamp: datetime_timestamp(attribute, options)
+          }
         ))
       end
 
@@ -72,6 +78,11 @@ module Godmin
       def datetime_value(attribute, options, format)
         value = options[:value] || @object.send(attribute)
         value.try(:strftime, @template.translate_scoped("datetimepickers.#{format}"))
+      end
+
+      def datetime_timestamp(attribute, options)
+        value = options[:value] || @object.send(attribute)
+        value.to_s
       end
     end
   end


### PR DESCRIPTION
Fixes #80 

This is one way to solve this issue... Are there other ways? A few remaining things:

- [ ] Timezones need to be synced between client and server. As should the date formats. Currently the server prints something like `2015-01-30 22:00:00 UTC` while the timepicker prints `2015-01-30T22:00:00+01:00`. I am also not convinced the timepicker should print timezone data at all...

- [ ] The switching of form values when submitting the form is very visible and looks a bit strange. Can this be avoided without having to do a bunch of hidden fields and stuff?

- [ ] Clean up the JS a bit

