### PR TITLE
[WIP] Datepicker format issue fix for default locale 

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,8 @@ If you wish to translate the datetimepicker, add the following to your `app/asse
 //= require godmin
 ```
 
+Please note that the datepickers default to en-GB, not en-US, because Rails cannot automatically parse en-US dates.
+
 ### Select boxes
 
 Make a [selectize.js](http://brianreavis.github.io/selectize.js/) select box out of a text field or select box:

--- a/app/assets/javascripts/godmin/index.js
+++ b/app/assets/javascripts/godmin/index.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require moment
+//= require moment/en-gb
 //= require bootstrap-sprockets
 //= require bootstrap-datetimepicker
 //= require selectize

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,5 +40,5 @@ en:
         zero: "No %{resource} found"
         other: "Showing %{count} out of %{total} %{resource}"
     datetimepickers:
-      datepicker: ! "%m/%d/%Y"
-      datetimepicker: ! "%m/%d/%Y%l:%M %p"
+      datepicker: ! "%d/%m/%Y"
+      datetimepicker: ! "%d/%m/%Y %H:%M"


### PR DESCRIPTION
Fixes #80 

Alternative solution to #110. This is much simpler and avoids dealing with US locales altogether. Perhaps this is the better solution, at least for now?

Should we make a note of this in the readme?