### PR TITLE
Removes the need for Godmin.namespace method

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,6 @@ Godmin should be up and running at `localhost:3000/admin`
 
 Installing Godmin does a number of things to the Rails application.
 
-A `config/initializers/godmin.rb` is created:
-```ruby
-Godmin.configure do |config|
-  config.namespace = nil
-end
-```
-
-If Godmin was installed inside an engine, as in the previous section, the namespace is the underscored name of the engine, e.g. `"admin"`.
-
 The application controller is modified as such:
 ```ruby
 class ApplicationController < ActionController::Base

--- a/app/views/layouts/godmin/_layout.html.erb
+++ b/app/views/layouts/godmin/_layout.html.erb
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title><%= t("godmin.title") %></title>
-    <%= stylesheet_link_tag [Godmin.namespace, "application"].compact.join("/"), media: "all" %>
-    <%= javascript_include_tag [Godmin.namespace, "application"].compact.join("/") %>
+    <%= stylesheet_link_tag [engine_namespace, "application"].compact.join("/"), media: "all" %>
+    <%= javascript_include_tag [engine_namespace, "application"].compact.join("/") %>
     <%= csrf_meta_tags %>
     <%= yield :head %>
   </head>

--- a/app/views/layouts/godmin/application.html.erb
+++ b/app/views/layouts/godmin/application.html.erb
@@ -6,10 +6,10 @@
       </div>
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-          <%= render partial: [Godmin.namespace, "shared/navigation"].compact.join("/") %>
+          <%= render partial: [engine_namespace, "shared/navigation"].compact.join("/") %>
         </ul>
         <ul class="nav navbar-nav navbar-right">
-          <%= render partial: [Godmin.namespace, "shared/navigation_aside"].compact.join("/") %>
+          <%= render partial: [engine_namespace, "shared/navigation_aside"].compact.join("/") %>
         </ul>
       </div>
     </div>

--- a/lib/generators/godmin/install/install_generator.rb
+++ b/lib/generators/godmin/install/install_generator.rb
@@ -1,16 +1,6 @@
 require "godmin/generators/base"
 
 class Godmin::InstallGenerator < Godmin::Generators::Base
-  def create_initializer
-    create_file "config/initializers/godmin.rb" do
-      <<-END.strip_heredoc
-        Godmin.configure do |config|
-          config.namespace = #{namespace ? "\"#{namespaced_path.join("/")}\"" : "nil"}
-        end
-      END
-    end
-  end
-
   def create_routes
     inject_into_file "config/routes.rb", before: /^end/ do
       <<-END.strip_heredoc.indent(2)

--- a/lib/godmin.rb
+++ b/lib/godmin.rb
@@ -9,6 +9,7 @@ require "godmin/application_controller"
 require "godmin/authentication"
 require "godmin/authorization"
 require "godmin/engine"
+require "godmin/engine_wrapper"
 require "godmin/paginator"
 require "godmin/resolver"
 require "godmin/resources/resource_controller"
@@ -16,10 +17,4 @@ require "godmin/resources/resource_service"
 require "godmin/version"
 
 module Godmin
-  mattr_accessor :namespace
-  self.namespace = nil
-
-  def self.configure
-    yield self
-  end
 end

--- a/lib/godmin/authorization.rb
+++ b/lib/godmin/authorization.rb
@@ -22,7 +22,7 @@ module Godmin
     end
 
     def policy(record)
-      policies[record] ||= PolicyFinder.find(record).new(admin_user, record)
+      policies[record] ||= PolicyFinder.find(record, engine_namespace).new(admin_user, record)
     end
 
     def policies

--- a/lib/godmin/authorization/policy_finder.rb
+++ b/lib/godmin/authorization/policy_finder.rb
@@ -2,7 +2,7 @@ module Godmin
   module Authorization
     class PolicyFinder
       class << self
-        def find(object)
+        def find(object, namespace)
           return object.policy_class if object.respond_to?(:policy_class)
           return object.class.policy_class if object.class.respond_to?(:policy_class)
           klass =
@@ -18,8 +18,8 @@ module Godmin
               object.class
             end
 
-          if Godmin.namespace
-            "#{Godmin.namespace.classify}::#{klass}Policy"
+          if namespace
+            "#{namespace.classify}::#{klass}Policy"
           else
             "#{klass}Policy"
           end.constantize

--- a/lib/godmin/engine_wrapper.rb
+++ b/lib/godmin/engine_wrapper.rb
@@ -1,0 +1,34 @@
+module Godmin
+  class EngineWrapper
+    attr_reader :engine
+
+    def initialize(obj)
+      @engine = find_engine(obj)
+    end
+
+    def root
+      engine.root
+    end
+
+    def namespace
+      engine.railtie_namespace.to_s.underscore
+    end
+
+    private
+
+    def find_engine(obj)
+      mod = find_engine_module(obj)
+      if mod
+        "#{mod}::Engine".constantize
+      else
+        Rails.application
+      end
+    end
+
+    def find_engine_module(obj)
+      obj.class.to_s.deconstantize.split("::").reverse.map(&:constantize).detect do |mod|
+        mod.respond_to?(:use_relative_model_naming?) && mod.use_relative_model_naming?
+      end
+    end
+  end
+end

--- a/lib/godmin/resolver.rb
+++ b/lib/godmin/resolver.rb
@@ -28,7 +28,7 @@ module Godmin
   class ResourceResolver < BaseResolver
     def template_paths(_name, prefix, _partial)
       [
-        File.join(@path, clean_prefix(prefix, @engine.name)),
+        File.join(@path, clean_prefix(prefix, @engine.namespace)),
         File.join(Godmin::Engine.root, "app/views", clean_prefix(prefix, "godmin"))
       ]
     end
@@ -53,7 +53,7 @@ module Godmin
     private
 
     def clean_prefix(prefix)
-      prefix.sub(/\A#{@engine.name}/, "")
+      prefix.sub(/\A#{@engine.namespace}/, "")
     end
   end
 end

--- a/lib/godmin/resolver.rb
+++ b/lib/godmin/resolver.rb
@@ -1,9 +1,8 @@
 module Godmin
   class BaseResolver < ::ActionView::FileSystemResolver
-    def initialize(controller_path)
-      super File.join(
-        [Rails.application.root, Godmin.namespace, "app/views"].compact
-      )
+    def initialize(controller_path, engine)
+      super File.join(engine.root, "app/views")
+      @engine = engine
       @controller_path = controller_path
     end
 
@@ -29,7 +28,7 @@ module Godmin
   class ResourceResolver < BaseResolver
     def template_paths(_name, prefix, _partial)
       [
-        File.join(@path, clean_prefix(prefix, Godmin.namespace)),
+        File.join(@path, clean_prefix(prefix, @engine.name)),
         File.join(Godmin::Engine.root, "app/views", clean_prefix(prefix, "godmin"))
       ]
     end
@@ -54,7 +53,7 @@ module Godmin
     private
 
     def clean_prefix(prefix)
-      prefix.gsub(/\A#{Godmin.namespace}\/?/, "")
+      prefix.sub(/\A#{@engine.name}/, "")
     end
   end
 end

--- a/test/dummy/config/initializers/godmin.rb
+++ b/test/dummy/config/initializers/godmin.rb
@@ -1,3 +1,0 @@
-Godmin.configure do |config|
-  config.namespace = nil
-end

--- a/test/lib/godmin/policy_finder_test.rb
+++ b/test/lib/godmin/policy_finder_test.rb
@@ -21,38 +21,28 @@ module Godmin
   module Authorization
     class PolicyFinderTest < ActiveSupport::TestCase
       def test_find_by_model
-        namespaced_as "namespace" do
-          policy = PolicyFinder.find(ArticlePolicyTest)
-          assert_equal Namespace::ArticlePolicyTestPolicy, policy
-        end
+        policy = PolicyFinder.find(ArticlePolicyTest, "namespace")
+        assert_equal Namespace::ArticlePolicyTestPolicy, policy
       end
 
       def test_find_by_class
-        namespaced_as "namespace" do
-          policy = PolicyFinder.find(Object)
-          assert_equal Namespace::ObjectPolicy, policy
-        end
+        policy = PolicyFinder.find(Object, "namespace")
+        assert_equal Namespace::ObjectPolicy, policy
       end
 
       def test_find_by_symbol
-        namespaced_as "namespace" do
-          policy = PolicyFinder.find(:article_policy_test)
-          assert_equal Namespace::ArticlePolicyTestPolicy, policy
-        end
+        policy = PolicyFinder.find(:article_policy_test, "namespace")
+        assert_equal Namespace::ArticlePolicyTestPolicy, policy
       end
 
       def test_override_policy_class_on_class
-        namespaced_as "namespace" do
-          policy = PolicyFinder.find(OverriddenPolicyTest)
-          assert_equal Namespace::ObjectPolicy, policy
-        end
+        policy = PolicyFinder.find(OverriddenPolicyTest, "namespace")
+        assert_equal Namespace::ObjectPolicy, policy
       end
 
       def test_override_policy_class_on_instance
-        namespaced_as "namespace" do
-          policy = PolicyFinder.find(OverriddenPolicyTest.new)
-          assert_equal Namespace::ObjectPolicy, policy
-        end
+        policy = PolicyFinder.find(OverriddenPolicyTest.new, "namespace")
+        assert_equal Namespace::ObjectPolicy, policy
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,12 +25,6 @@ if ActiveSupport::TestCase.method_defined?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 end
 
-def namespaced_as(namespace)
-  Godmin.namespace = namespace
-  yield
-  Godmin.namespace = nil
-end
-
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 


### PR DESCRIPTION
This PR aims to remove the need for `Godmin.namespace` by finding the namespace automatically. :eyes: