### PR TITLE
Refactors the engine wrapper + adds tests

### DIFF
--- a/app/views/layouts/godmin/_layout.html.erb
+++ b/app/views/layouts/godmin/_layout.html.erb
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title><%= t("godmin.title") %></title>
-    <%= stylesheet_link_tag [engine_namespace, "application"].compact.join("/"), media: "all" %>
-    <%= javascript_include_tag [engine_namespace, "application"].compact.join("/") %>
+    <%= stylesheet_link_tag File.join(engine_wrapper.namespaced_path, "application"), media: "all" %>
+    <%= javascript_include_tag File.join(engine_wrapper.namespaced_path, "application") %>
     <%= csrf_meta_tags %>
     <%= yield :head %>
   </head>

--- a/app/views/layouts/godmin/application.html.erb
+++ b/app/views/layouts/godmin/application.html.erb
@@ -6,10 +6,10 @@
       </div>
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-          <%= render partial: [engine_namespace, "shared/navigation"].compact.join("/") %>
+          <%= render partial: File.join(engine_wrapper.namespaced_path, "shared/navigation") %>
         </ul>
         <ul class="nav navbar-nav navbar-right">
-          <%= render partial: [engine_namespace, "shared/navigation_aside"].compact.join("/") %>
+          <%= render partial: File.join(engine_wrapper.namespaced_path, "shared/navigation_aside") %>
         </ul>
       </div>
     </div>

--- a/lib/godmin/application_controller.rb
+++ b/lib/godmin/application_controller.rb
@@ -17,7 +17,6 @@ module Godmin
 
       helper_method :authentication_enabled?
       helper_method :authorization_enabled?
-      helper_method :engine_namespace
       helper_method :engine_wrapper
 
       before_action :append_view_paths
@@ -29,12 +28,8 @@ module Godmin
 
     private
 
-    def engine_namespace
-      engine_wrapper.namespace
-    end
-
     def engine_wrapper
-      EngineWrapper.new(self)
+      EngineWrapper.new(self.class)
     end
 
     def append_view_paths

--- a/lib/godmin/application_controller.rb
+++ b/lib/godmin/application_controller.rb
@@ -33,8 +33,7 @@ module Godmin
     end
 
     def append_view_paths
-      append_view_path Godmin::ResourceResolver.new(controller_path, engine_wrapper)
-      append_view_path Godmin::GodminResolver.new(controller_path, engine_wrapper)
+      append_view_path Godmin::Resolver.new(controller_path, engine_wrapper)
     end
 
     def authentication_enabled?

--- a/lib/godmin/authorization/policy_finder.rb
+++ b/lib/godmin/authorization/policy_finder.rb
@@ -2,9 +2,10 @@ module Godmin
   module Authorization
     class PolicyFinder
       class << self
-        def find(object, namespace)
+        def find(object, namespace = nil)
           return object.policy_class if object.respond_to?(:policy_class)
           return object.class.policy_class if object.class.respond_to?(:policy_class)
+
           klass =
             if object.respond_to?(:model_name)
               object.model_name

--- a/lib/godmin/engine_wrapper.rb
+++ b/lib/godmin/engine_wrapper.rb
@@ -2,32 +2,47 @@ module Godmin
   class EngineWrapper
     attr_reader :engine
 
-    def initialize(obj)
-      @engine = find_engine(obj)
+    def initialize(controller)
+      @engine = find_engine(controller)
+    end
+
+    def namespace
+      @namespace ||= engine.railtie_namespace
+    end
+
+    def namespaced?
+      @namespaced ||= namespace.present?
+    end
+
+    def namespaced_path
+      @namespaced_path ||= begin
+        if namespaced?
+          namespace.name.classify.split("::").map(&:underscore)
+        else
+          []
+        end
+      end
     end
 
     def root
       engine.root
     end
 
-    def namespace
-      engine.railtie_namespace.to_s.underscore
-    end
-
     private
 
-    def find_engine(obj)
-      mod = find_engine_module(obj)
-      if mod
-        "#{mod}::Engine".constantize
+    def find_engine(controller)
+      engine_module = find_engine_module(controller)
+
+      if engine_module
+        "#{engine_module}::Engine".constantize
       else
         Rails.application
       end
     end
 
-    def find_engine_module(obj)
-      obj.class.to_s.deconstantize.split("::").reverse.map(&:constantize).detect do |mod|
-        mod.respond_to?(:use_relative_model_naming?) && mod.use_relative_model_naming?
+    def find_engine_module(controller)
+      controller.parents.find do |parent|
+        parent.respond_to?(:use_relative_model_naming?) && parent.use_relative_model_naming?
       end
     end
   end

--- a/lib/godmin/resolver.rb
+++ b/lib/godmin/resolver.rb
@@ -1,8 +1,8 @@
 module Godmin
   class BaseResolver < ::ActionView::FileSystemResolver
-    def initialize(controller_path, engine)
-      super File.join(engine.root, "app/views")
-      @engine = engine
+    def initialize(controller_path, engine_wrapper)
+      super File.join(engine_wrapper.root, "app/views")
+      @engine_namespace = engine_wrapper.namespace.to_s.underscore
       @controller_path = controller_path
     end
 
@@ -28,7 +28,7 @@ module Godmin
   class ResourceResolver < BaseResolver
     def template_paths(_name, prefix, _partial)
       [
-        File.join(@path, clean_prefix(prefix, @engine.namespace)),
+        File.join(@path, clean_prefix(prefix, @engine_namespace)),
         File.join(Godmin::Engine.root, "app/views", clean_prefix(prefix, "godmin"))
       ]
     end
@@ -53,7 +53,7 @@ module Godmin
     private
 
     def clean_prefix(prefix)
-      prefix.sub(/\A#{@engine.namespace}/, "")
+      prefix.sub(/\A#{@engine_namespace}/, "")
     end
   end
 end

--- a/lib/godmin/resolver.rb
+++ b/lib/godmin/resolver.rb
@@ -1,15 +1,15 @@
 module Godmin
-  class BaseResolver < ::ActionView::FileSystemResolver
+  class Resolver < ::ActionView::FileSystemResolver
     def initialize(controller_path, engine_wrapper)
-      super File.join(engine_wrapper.root, "app/views")
-      @engine_namespace = engine_wrapper.namespace.to_s.underscore
+      super ""
       @controller_path = controller_path
+      @engine_wrapper = engine_wrapper
     end
 
     def find_templates(name, prefix, partial, details)
       templates = []
 
-      template_paths(name, prefix, partial).each do |path|
+      template_paths(prefix).each do |path|
         if templates.present?
           break
         else
@@ -19,41 +19,34 @@ module Godmin
 
       templates
     end
-  end
 
-  # Matches templates such as:
-  # { name: index } => [app/views/resource/index, godmin/app/views/godmin/resource/index]
-  # { name: form } => [app/views/resource/_form, godmin/app/views/godmin/resource/_form]
-  # { name: title } => [app/views/resource/columns/_title]
-  class ResourceResolver < BaseResolver
-    def template_paths(_name, prefix, _partial)
+    # Matches templates such as:
+    #
+    # { name: index, prefix: articles }      => [app/views/resource/index, godmin/app/views/godmin/resource/index]
+    # { name: form, prefix: articles }       => [app/views/resource/_form, godmin/app/views/godmin/resource/_form]
+    # { name: title, prefix: columns }       => [app/views/resource/columns/_title]
+    # { name: welcome, prefix: application } => [godmin/app/views/godmin/application/welcome]
+    # { name: navigation, prefix: shared }   => [godmin/app/views/godmin/shared/navigation]
+    def template_paths(prefix)
       [
-        File.join(@path, clean_prefix(prefix, @engine_namespace)),
-        File.join(Godmin::Engine.root, "app/views", clean_prefix(prefix, "godmin"))
+        File.join(@engine_wrapper.root, "app/views", resource_path_for_engine(prefix)),
+        File.join(Godmin::Engine.root, "app/views/godmin", resource_path_for_godmin(prefix)),
+        File.join(Godmin::Engine.root, "app/views/godmin", default_path_for_godmin(prefix))
       ]
     end
 
     private
 
-    def clean_prefix(prefix, namespace)
-      prefix.sub(/\A#{@controller_path}/, [namespace, "resource"].compact.join("/"))
-    end
-  end
-
-  # Matches templates such as:
-  # { name: welcome, prefix: application } => [godmin/app/views/godmin/application/welcome]
-  # { name: navigation, prefix: shared } => [godmin/app/views/godmin/shared/navigation]
-  class GodminResolver < BaseResolver
-    def template_paths(_name, prefix, _partial)
-      [
-        File.join(Godmin::Engine.root, "app/views/godmin", clean_prefix(prefix))
-      ]
+    def resource_path_for_engine(prefix)
+      prefix.sub(/\A#{@controller_path}/, File.join(@engine_wrapper.namespaced_path, "resource"))
     end
 
-    private
+    def resource_path_for_godmin(prefix)
+      prefix.sub(/\A#{@controller_path}/, "resource")
+    end
 
-    def clean_prefix(prefix)
-      prefix.sub(/\A#{@engine_namespace}/, "")
+    def default_path_for_godmin(prefix)
+      prefix.sub(/\A#{File.join(@engine_wrapper.namespaced_path)}/, "")
     end
   end
 end

--- a/test/lib/godmin/engine_wrapper_test.rb
+++ b/test/lib/godmin/engine_wrapper_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+module Godmin
+  class EngineWrapperTest < ActiveSupport::TestCase
+    module FooBarBaz
+      class Engine < Rails::Engine
+        isolate_namespace FooBarBaz
+      end
+
+      class Controller < ActionController::Base; end
+    end
+
+    class Controller < ActionController::Base; end
+
+    def test_default_namespace
+      engine_wrapper = EngineWrapper.new(Controller)
+      assert_equal nil, engine_wrapper.namespace
+    end
+
+    def test_default_namespaced?
+      engine_wrapper = EngineWrapper.new(Controller)
+      assert_equal false, engine_wrapper.namespaced?
+    end
+
+    def test_default_namespaced_path
+      engine_wrapper = EngineWrapper.new(Controller)
+      assert_equal [], engine_wrapper.namespaced_path
+    end
+
+    def test_default_root
+      engine_wrapper = EngineWrapper.new(Controller)
+      assert_equal Rails.application.root, engine_wrapper.root
+    end
+
+    def test_engine_namespace
+      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
+      assert_equal FooBarBaz, engine_wrapper.namespace
+    end
+
+    def test_engine_namespaced?
+      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
+      assert_equal true, engine_wrapper.namespaced?
+    end
+
+    def test_engine_namespaced_path
+      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
+      assert_equal ["godmin", "engine_wrapper_test", "foo_bar_baz"], engine_wrapper.namespaced_path
+    end
+
+    def test_engine_root
+      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
+      assert_equal FooBarBaz::Engine.root, engine_wrapper.root
+    end
+  end
+end

--- a/test/lib/godmin/engine_wrapper_test.rb
+++ b/test/lib/godmin/engine_wrapper_test.rb
@@ -2,9 +2,9 @@ require "test_helper"
 
 module Godmin
   class EngineWrapperTest < ActiveSupport::TestCase
-    module FooBarBaz
+    module Admin
       class Engine < Rails::Engine
-        isolate_namespace FooBarBaz
+        isolate_namespace Admin
       end
 
       class Controller < ActionController::Base; end
@@ -33,23 +33,23 @@ module Godmin
     end
 
     def test_engine_namespace
-      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
-      assert_equal FooBarBaz, engine_wrapper.namespace
+      engine_wrapper = EngineWrapper.new(Admin::Controller)
+      assert_equal Admin, engine_wrapper.namespace
     end
 
     def test_engine_namespaced?
-      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
+      engine_wrapper = EngineWrapper.new(Admin::Controller)
       assert_equal true, engine_wrapper.namespaced?
     end
 
     def test_engine_namespaced_path
-      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
-      assert_equal ["godmin", "engine_wrapper_test", "foo_bar_baz"], engine_wrapper.namespaced_path
+      engine_wrapper = EngineWrapper.new(Admin::Controller)
+      assert_equal ["godmin", "engine_wrapper_test", "admin"], engine_wrapper.namespaced_path
     end
 
     def test_engine_root
-      engine_wrapper = EngineWrapper.new(FooBarBaz::Controller)
-      assert_equal FooBarBaz::Engine.root, engine_wrapper.root
+      engine_wrapper = EngineWrapper.new(Admin::Controller)
+      assert_equal Admin::Engine.root, engine_wrapper.root
     end
   end
 end

--- a/test/lib/godmin/policy_finder_test.rb
+++ b/test/lib/godmin/policy_finder_test.rb
@@ -1,48 +1,54 @@
 require "test_helper"
 
-module Namespace
-  class ArticlePolicyTestPolicy; end
-  class ObjectPolicy; end
-end
-
-class ArticlePolicyTest; extend ActiveModel::Naming; end
-class OverriddenPolicyTest
-  extend ActiveModel::Naming
-  def self.policy_class
-    Namespace::ObjectPolicy
-  end
-
-  def policy_class
-    Namespace::ObjectPolicy
-  end
-end
-
 module Godmin
   module Authorization
     class PolicyFinderTest < ActiveSupport::TestCase
+      class Article; end
+      class ArticlePolicy; end
+
       def test_find_by_model
-        policy = PolicyFinder.find(ArticlePolicyTest, "namespace")
-        assert_equal Namespace::ArticlePolicyTestPolicy, policy
+        klass = Class.new do
+          extend ActiveModel::Naming
+
+          def self.name
+            "Article"
+          end
+        end
+
+        policy = PolicyFinder.find(klass, "godmin/authorization/policy_finder_test")
+        assert_equal ArticlePolicy, policy
       end
 
       def test_find_by_class
-        policy = PolicyFinder.find(Object, "namespace")
-        assert_equal Namespace::ObjectPolicy, policy
+        policy = PolicyFinder.find(Article)
+        assert_equal ArticlePolicy, policy
       end
 
       def test_find_by_symbol
-        policy = PolicyFinder.find(:article_policy_test, "namespace")
-        assert_equal Namespace::ArticlePolicyTestPolicy, policy
+        policy = PolicyFinder.find(:article, "godmin/authorization/policy_finder_test")
+        assert_equal ArticlePolicy, policy
       end
 
       def test_override_policy_class_on_class
-        policy = PolicyFinder.find(OverriddenPolicyTest, "namespace")
-        assert_equal Namespace::ObjectPolicy, policy
+        klass = Class.new do
+          def self.policy_class
+            ArticlePolicy
+          end
+        end
+
+        policy = PolicyFinder.find(klass)
+        assert_equal ArticlePolicy, policy
       end
 
       def test_override_policy_class_on_instance
-        policy = PolicyFinder.find(OverriddenPolicyTest.new, "namespace")
-        assert_equal Namespace::ObjectPolicy, policy
+        klass = Class.new do
+          def policy_class
+            ArticlePolicy
+          end
+        end
+
+        policy = PolicyFinder.find(klass.new)
+        assert_equal ArticlePolicy, policy
       end
     end
   end

--- a/test/lib/godmin/resources/resource_service/pagination_test.rb
+++ b/test/lib/godmin/resources/resource_service/pagination_test.rb
@@ -4,7 +4,7 @@ module Godmin
   module ResourceService
     class PaginationTest < ActiveSupport::TestCase
       def setup
-        @article_service = ArticleService.new
+        @article_service = Fakes::ArticleService.new
 
         resources_class = Class.new do
           def limit(_limit_param)

--- a/test/lib/godmin/resources/resource_service/scopes_test.rb
+++ b/test/lib/godmin/resources/resource_service/scopes_test.rb
@@ -3,17 +3,17 @@ require "test_helper"
 module Godmin
   module ResourceService
     class ScopesTest < ActiveSupport::TestCase
-      class NoScopesService
-        include Godmin::Resources::ResourceService
-      end
-
       def setup
         @article_service = Fakes::ArticleService.new
       end
 
       def test_returns_resources_when_no_scopes_are_defined
-        @foo_thing = NoScopesService.new
-        assert_equal :resources, @foo_thing.apply_scope("", :resources)
+        service_class = Class.new do
+          include Godmin::Resources::ResourceService
+        end
+
+        service = service_class.new
+        assert_equal :resources, service.apply_scope("", :resources)
       end
 
       def test_calls_default_scope


### PR DESCRIPTION
- Consolidates the engine wrapper with how namespaces are implemented in the generators, e.g. `namespaced_path`, which works better with `File.join`
- Use the `parents` method instead of our own when looking up the parent chain, which works better because it can detect nested engines, e.g. `Foo::Bar::Baz::Engine`, which resolves into something like `[Foo::Bar::Baz, Foo::Bar, Foo]` instead of `[Foo, Bar, Baz]`
- Adds tests for the `EngineWrapper`
- Cleans up the global namespace a bit, in the `PolicyFinder` tests for instance

The resolver can also take advantage of the new `namespaced_path` method, but I've left that for another PR, perhaps when we add back the resolver tests