### PR TITLE
Support engines with plural names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+Bug fixes
+- Adds support for plural engines (https://github.com/varvet/godmin/pull/128)
+
 ### 0.12.2 - 2015-09-07
 Bug fixes
 - Fixes broken sign in page

--- a/lib/godmin/engine_wrapper.rb
+++ b/lib/godmin/engine_wrapper.rb
@@ -17,7 +17,7 @@ module Godmin
     def namespaced_path
       @namespaced_path ||= begin
         if namespaced?
-          namespace.name.classify.split("::").map(&:underscore)
+          namespace.name.split("::").map(&:underscore)
         else
           []
         end

--- a/lib/godmin/generators/base.rb
+++ b/lib/godmin/generators/base.rb
@@ -22,7 +22,7 @@ module Godmin
       def namespaced_path
         @namespaced_path ||= begin
           if namespaced?
-            namespace.name.classify.split("::").map(&:underscore)
+            namespace.name.split("::").map(&:underscore)
           else
             []
           end

--- a/test/lib/godmin/engine_wrapper_test.rb
+++ b/test/lib/godmin/engine_wrapper_test.rb
@@ -10,6 +10,14 @@ module Godmin
       class Controller < ActionController::Base; end
     end
 
+    module Admins
+      class Engine < Rails::Engine
+        isolate_namespace Admins
+      end
+
+      class Controller < ActionController::Base; end
+    end
+
     class Controller < ActionController::Base; end
 
     def test_default_namespace
@@ -45,6 +53,11 @@ module Godmin
     def test_engine_namespaced_path
       engine_wrapper = EngineWrapper.new(Admin::Controller)
       assert_equal ["godmin", "engine_wrapper_test", "admin"], engine_wrapper.namespaced_path
+    end
+
+    def test_plural_engine_namespaced_path
+      engine_wrapper = EngineWrapper.new(Admins::Controller)
+      assert_equal ["godmin", "engine_wrapper_test", "admins"], engine_wrapper.namespaced_path
     end
 
     def test_engine_root


### PR DESCRIPTION
Don't use classify for engine namespace
When using .classify on a string it is also singularized (http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-classify)

Fixes #127 

Do we want to keep the test? I used it when debugging the issue.