### PR TITLE
Move moment and moment/locale require to install generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### 0.12.4
+Bug fixes
+- Fixes a bug which made it impossible to override the datetimepicker locale (https://github.com/varvet/godmin/issues/132)
 
 ### 0.12.3 - 2015-09-18
 Bug fixes

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ Godmin.Datetimepickers.initializeDatetimepicker($el, {
 });
 ```
 
-If you wish to translate the datetimepicker, add the following to your `app/assets/javascripts/application.js`:
+If you wish to translate the datetimepicker, change `moment/en-gb` in your `app/assets/javascripts/application.js` to your desired locale:
 
 ```js
 //= require moment

--- a/app/assets/javascripts/godmin/index.js
+++ b/app/assets/javascripts/godmin/index.js
@@ -12,8 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require moment
-//= require moment/en-gb
 //= require bootstrap-sprockets
 //= require bootstrap-datetimepicker
 //= require selectize

--- a/lib/generators/godmin/install/install_generator.rb
+++ b/lib/generators/godmin/install/install_generator.rb
@@ -25,7 +25,11 @@ class Godmin::InstallGenerator < Godmin::Generators::Base
     application_js = File.join("app/assets/javascripts", namespaced_path, "application.js")
 
     inject_into_file application_js, before: "//= require_tree ." do
-      "//= require godmin\n"
+      <<-END.strip_heredoc
+        //= require moment
+        //= require moment/en-gb
+        //= require godmin
+      END
     end
 
     gsub_file application_js, /\/\/= require turbolinks\n/, ""


### PR DESCRIPTION
This should fix the issue described in #132 

Instead of requiring `moment` and `moment/en-gb` in Godmin, we add those to the appropriate `application.js` file on install. So, to use another locale, just change `moment/en-gb` to whatever you want.

I moved `require 'moment'` as well, because it need to be required before `moment/locale` is required...

Another option would be some kind of config, either in a godmin initializer or a global js config.

Any thoughts on this, @jensljungblad ?

Fixes #132 