### PR TITLE
Creating locale for pt-BR (Brazilian Portuguese)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  helpers:
+    submit:
+      create: Create
   godmin:
     title: Godmin
     batch_actions:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,44 @@
+pt-BR:
+  godmin:
+    title: Godmin
+    batch_actions:
+      buttons:
+        select_all: Selecionar todos
+        deselect_all: Remover seleção
+      confirm_message: Você tem certeza?
+    filters:
+      select:
+        placeholder:
+          one: Selecionar um
+          many: Selecionar vários
+      buttons:
+        apply: Filtrar
+        clear: Limpar filtro
+    actions:
+      label: Ações
+      show: Exibir
+      edit: Editar
+      destroy: Remover
+      confirm_message: Você tem certeza?
+      export: Exportar
+      export_as: Como
+    sessions:
+      sign_in: Entrar
+      sign_out: Sair
+      signed_in: Conectado
+      signed_out: Desconectado
+      failed_sign_in: Credenciais inválidas
+    flash:
+      create: "%{resource} foi criado com sucesso"
+      update: "%{resource} foi atualizado com sucesso"
+      destroy: "%{resource} foi removido com sucesso"
+      batch_action: "%{number_of_affected_records} de %{total_number_of_records} %{resource} foram modificados"
+    pagination:
+      first: "Primeiro"
+      last: "Último"
+      entries:
+        zero: "Nenhum %{resource} encontrado"
+        other: "Exibindo %{count} de %{total} %{resource}"
+    datetimepickers:
+      datepicker: ! "%d/%m/%Y"
+      datetimepicker: ! "%d/%m/%Y %H:%M"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,4 +1,7 @@
 pt-BR:
+  helpers:
+    submit:
+      create: Novo
   godmin:
     title: Godmin
     batch_actions:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -1,4 +1,7 @@
 sv:
+  helpers:
+    submit:
+      create: Skapa
   godmin:
     title: Godmin
     batch_actions:

--- a/test/integration/template_overriding_test.rb
+++ b/test/integration/template_overriding_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class TemplateOverridingTest < ActionDispatch::IntegrationTest
   def test_default_template
     visit articles_path
-    assert page.has_content? "Create Article"
+    assert page.has_content? "Create"
   end
 
   def test_override_template
@@ -27,7 +27,7 @@ class TemplateOverridingTest < ActionDispatch::IntegrationTest
 
   def test_default_template_in_engine
     visit admin.articles_path
-    assert page.has_content? "Create Article"
+    assert page.has_content? "Create"
   end
 
   def test_override_template_in_engine


### PR DESCRIPTION
With this commit the application will have a pt-BR locale
available for usage.

I've tested using the sandbox application pointing to my GH fork and it was ok.
Also, I've noticed that some interface items (like the 'Created' button) is not on the translation file.
Whenever you make changes or add new translation items, feel free to ping me for updating the translation.
