### PR TITLE
Reverts back to two resolvers in order to fix #139

### DIFF
--- a/lib/godmin/application_controller.rb
+++ b/lib/godmin/application_controller.rb
@@ -33,7 +33,7 @@ module Godmin
     end
 
     def append_view_paths
-      append_view_path Godmin::Resolver.new(controller_path, engine_wrapper)
+      append_view_path Godmin::Resolver.resolvers(controller_path, engine_wrapper)
     end
 
     def authentication_enabled?

--- a/lib/godmin/resolver.rb
+++ b/lib/godmin/resolver.rb
@@ -1,7 +1,14 @@
 module Godmin
   class Resolver < ::ActionView::FileSystemResolver
-    def initialize(controller_path, engine_wrapper)
-      super ""
+    def self.resolvers(controller_path, engine_wrapper)
+      [
+        EngineResolver.new(controller_path, engine_wrapper),
+        GodminResolver.new(controller_path, engine_wrapper)
+      ]
+    end
+
+    def initialize(path, controller_path, engine_wrapper)
+      super(path)
       @controller_path = controller_path
       @engine_wrapper = engine_wrapper
     end
@@ -19,34 +26,53 @@ module Godmin
 
       templates
     end
+  end
 
-    # Matches templates such as:
-    #
-    # { name: index, prefix: articles }      => [app/views/resource/index, godmin/app/views/godmin/resource/index]
-    # { name: form, prefix: articles }       => [app/views/resource/_form, godmin/app/views/godmin/resource/_form]
-    # { name: title, prefix: columns }       => [app/views/resource/columns/_title]
-    # { name: welcome, prefix: application } => [godmin/app/views/godmin/application/welcome]
-    # { name: navigation, prefix: shared }   => [godmin/app/views/godmin/shared/navigation]
+  # Matches templates such as:
+  #
+  # { name: index, prefix: articles } => app/views/resource/index
+  # { name: form, prefix: articles }  => app/views/resource/_form
+  # { name: title, prefix: columns }  => app/views/resource/columns/_title
+  class EngineResolver < Resolver
+    def initialize(controller_path, engine_wrapper)
+      super(File.join(engine_wrapper.root, "app/views"), controller_path, engine_wrapper)
+    end
+
     def template_paths(prefix)
       [
-        File.join(@engine_wrapper.root, "app/views", resource_path_for_engine(prefix)),
-        File.join(Godmin::Engine.root, "app/views/godmin", default_path_for_godmin(prefix)),
-        File.join(Godmin::Engine.root, "app/views/godmin", resource_path_for_godmin(prefix))
+        resource_path_for_engine(prefix)
       ]
     end
 
-    private
-
     def resource_path_for_engine(prefix)
-      prefix.sub(/\A#{@controller_path}/, File.join(@engine_wrapper.namespaced_path, "resource"))
+      prefix.sub(/\A#{@controller_path}/, File.join(@engine_wrapper.namespaced_path, "resource")).sub(/\A\//, "")
+    end
+  end
+
+  # Matches templates such as:
+  #
+  # { name: index, prefix: articles }      => godmin/app/views/godmin/resource/index
+  # { name: form, prefix: articles }       => godmin/app/views/godmin/resource/_form
+  # { name: welcome, prefix: application } => godmin/app/views/godmin/application/welcome
+  # { name: navigation, prefix: shared }   => godmin/app/views/godmin/shared/navigation
+  class GodminResolver < Resolver
+    def initialize(controller_path, engine_wrapper)
+      super(File.join(Godmin::Engine.root, "app/views/godmin"), controller_path, engine_wrapper)
     end
 
-    def resource_path_for_godmin(prefix)
-      prefix.sub(/\A#{@controller_path}/, "resource")
+    def template_paths(prefix)
+      [
+        default_path_for_godmin(prefix),
+        resource_path_for_godmin(prefix)
+      ]
     end
 
     def default_path_for_godmin(prefix)
-      prefix.sub(/\A#{File.join(@engine_wrapper.namespaced_path)}/, "")
+      prefix.sub(/\A#{File.join(@engine_wrapper.namespaced_path)}/, "").sub(/\A\//, "")
+    end
+
+    def resource_path_for_godmin(prefix)
+      prefix.sub(/\A#{@controller_path}/, "resource").sub(/\A\//, "")
     end
   end
 end

--- a/test/lib/godmin/resolver_test.rb
+++ b/test/lib/godmin/resolver_test.rb
@@ -17,23 +17,37 @@ module Godmin
       @engine_wrapper_2 = EngineWrapper.new(Admin::Controller)
     end
 
-    def test_godmin_resolver_when_not_namespaced
-      resolver = Resolver.new("articles", @engine_wrapper_1)
+    def test_engine_resolver_when_not_namespaced
+      resolver = EngineResolver.new("articles", @engine_wrapper_1)
 
       assert_equal [
-        File.join(@engine_wrapper_1.root, "app/views/resource"),
-        File.join(Godmin::Engine.root, "app/views/godmin/articles"),
-        File.join(Godmin::Engine.root, "app/views/godmin/resource")
+        "resource"
+      ], resolver.template_paths("articles")
+    end
+
+    def test_engine_resolver_when_namespaced
+      resolver = EngineResolver.new("godmin/resolver_test/admin/articles", @engine_wrapper_2)
+
+      assert_equal [
+        "godmin/resolver_test/admin/resource"
+      ], resolver.template_paths("godmin/resolver_test/admin/articles")
+    end
+
+    def test_godmin_resolver_when_not_namespaced
+      resolver = GodminResolver.new("articles", @engine_wrapper_1)
+
+      assert_equal [
+        "articles",
+        "resource"
       ], resolver.template_paths("articles")
     end
 
     def test_godmin_resolver_when_namespaced
-      resolver = Resolver.new("godmin/resolver_test/admin/articles", @engine_wrapper_2)
+      resolver = GodminResolver.new("godmin/resolver_test/admin/articles", @engine_wrapper_2)
 
       assert_equal [
-        File.join(@engine_wrapper_2.root, "app/views/godmin/resolver_test/admin/resource"),
-        File.join(Godmin::Engine.root, "app/views/godmin/articles"),
-        File.join(Godmin::Engine.root, "app/views/godmin/resource")
+        "articles",
+        "resource"
       ], resolver.template_paths("godmin/resolver_test/admin/articles")
     end
   end


### PR DESCRIPTION
Alternative to the solution provided by https://github.com/varvet/godmin/pull/140

Apparently our single resolver was unable to reload templates in case of an exception in the view. Probably because we used absolute template paths instead of setting a resolver base path and then use relative template paths.