### PR TITLE
Fix doc "wrong number of arguments (1 for 0)" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ To add to the resources query, e.g. to change the default order:
 class ArticleService
   include Godmin::Resources::ResourceService
 
-  def resources
-    super.order(author: :desc)
+  def resources(params)
+    super(params).order(author: :desc)
   end
 end
 ```


### PR DESCRIPTION
I'm not sure this is intended.

Another approach would be to pass the args implicitly to the super class as such

```ruby
def resources(*)
  super.order(author: :desc)
end
```