### PR TITLE
Fix responsive views

### DIFF
--- a/app/views/layouts/godmin/_layout.html.erb
+++ b/app/views/layouts/godmin/_layout.html.erb
@@ -5,6 +5,7 @@
     <%= stylesheet_link_tag File.join(engine_wrapper.namespaced_path, "application").gsub(/^\//, ""), media: "all" %>
     <%= javascript_include_tag File.join(engine_wrapper.namespaced_path, "application").gsub(/^\//, "") %>
     <%= csrf_meta_tags %>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= yield :head %>
   </head>
   <body>

--- a/app/views/layouts/godmin/application.html.erb
+++ b/app/views/layouts/godmin/application.html.erb
@@ -2,9 +2,15 @@
   <nav class="navbar navbar-default navbar-static-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#godmin-navbar-collapse" aria-expanded="false">
+          <span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
         <%= link_to t("godmin.title"), root_path, class: "navbar-brand" %>
       </div>
-      <div class="collapse navbar-collapse">
+      <div class="collapse navbar-collapse" id="godmin-navbar-collapse">
         <ul class="nav navbar-nav">
           <%= render partial: File.join(engine_wrapper.namespaced_path, "shared/navigation") %>
         </ul>


### PR DESCRIPTION
On mobile browsers, this meta tag is important for the bootstrap rules
to kick in properly.

For instance, if you navigate to http://godmin-sandbox.herokuapp.com, the UI is not responsive with my iphone)