### PR TITLE
Sandbox reseed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,9 +57,7 @@ namespace :sandbox do
   task :reseed do
     app = "godmin-sandbox"
     Bundler.with_clean_env do
-      system("heroku pg:reset DATABASE_URL --confirm #{app}")
-      system("heroku run rake db:migrate --app #{app}")
-      system("heroku run rake db:seed --app #{app}")
+      system("heroku run rake sandbox:reseed --app #{app}")
     end
   end
 end


### PR DESCRIPTION
We want to reseed the sandbox every day via Heroku's [Scheduler](https://devcenter.heroku.com/articles/scheduler). The Scheduler executes rake tasks. Sadly, neither `rake db:reset` or `rake db:drop` work on Heroku. They recommend `heroku pg:reset`, however that is tricky to execute via rake. We need a workaround.
- [x] Create a new sandbox rake task
- [x] Figure out a nice way to drop tables
- [x] Make sure that godmin's `sandbox:reseed` rake task points to the newly created task
- [x] Configure Scheduler to run `rake sandbox:reseed` every day