### PR TITLE
Batch action relations instead of arrays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Metrics/LineLength:
 Metrics/ClassLength:
   Max: 300
 
+Metrics/ModuleLength:
+  Max: 300
+
 Metrics/MethodLength:
   Max: 25
 

--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ end
 ```
 
 ### Batch action authorization
-Batch actions must be authorized in your policy if you are using Godmin's built in authorization functionality. The policy method is called with the list of all records to be processed.
+Batch actions must be authorized in your policy if you are using Godmin's built in authorization functionality. The policy method is called with the relation containing all records to be processed.
 
 ```ruby
 class ArticlePolicy < Godmin::Authorization::Policy

--- a/README.md
+++ b/README.md
@@ -737,12 +737,12 @@ end
 ```
 
 ### Batch action authorization
-Batch actions must be authorized in your policy if you are using Godmin's built in authorization functionality. The policy method is called once for each record before they are passed to the batch action method defined by the user. If a user is not allowed to "batch action" a particular record, it will be filtered out before passed to the batch action method. Note that this does not raise any `NotAuthorizedError`.
+Batch actions must be authorized in your policy if you are using Godmin's built in authorization functionality. The policy method is called with the list of all records to be processed.
 
 ```ruby
 class ArticlePolicy < Godmin::Authorization::Policy
   def batch_action_destroy?
-    @record.user_id == user.id
+		record.all? { |r| r.user_id == user.id }
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ Batch actions must be authorized in your policy if you are using Godmin's built 
 ```ruby
 class ArticlePolicy < Godmin::Authorization::Policy
   def batch_action_destroy?
-		record.all? { |r| r.user_id == user.id }
+    record.all? { |r| r.user_id == user.id }
   end
 end
 ```

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
       create: "%{resource} was successfully created"
       update: "%{resource} was successfully updated"
       destroy: "%{resource} was successfully destroyed"
-      batch_action: "%{number_of_affected_records} of %{total_number_of_records} %{resource} were affected"
+      batch_action: "%{number_of_records} %{resource} were affected"
     pagination:
       first: "First"
       last: "Last"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -32,7 +32,7 @@ pt-BR:
       create: "%{resource} foi criado com sucesso"
       update: "%{resource} foi atualizado com sucesso"
       destroy: "%{resource} foi removido com sucesso"
-      batch_action: "%{number_of_affected_records} de %{total_number_of_records} %{resource} foram modificados"
+      batch_action: "%{number_of_records} %{resource} foram modificados"
     pagination:
       first: "Primeiro"
       last: "Último"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -32,7 +32,7 @@ sv:
       create: "%{resource} skapades"
       update: "%{resource} uppdaterades"
       destroy: "%{resource} togs bort"
-      batch_action: "%{number_of_affected_records} av %{total_number_of_records} %{resource} påverkades"
+      batch_action: "%{number_of_records} %{resource} påverkades"
     pagination:
       first: "Första"
       last: "Sista"

--- a/godmin.gemspec
+++ b/godmin.gemspec
@@ -32,8 +32,9 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "capybara"
   gem.add_development_dependency "m"
-  gem.add_development_dependency "minitest"
   gem.add_development_dependency "minitest-reporters"
+  gem.add_development_dependency "minitest"
+  gem.add_development_dependency "poltergeist"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "sqlite3"
 end

--- a/lib/godmin/resources/resource_controller.rb
+++ b/lib/godmin/resources/resource_controller.rb
@@ -183,9 +183,8 @@ module Godmin
             )
             flash[:updated_ids] = batch_action_ids
 
-            # TODO: write test for this
             if respond_to?("redirect_after_batch_action_#{params[:batch_action]}", true)
-              redirect_to send("redirect_after_batch_action_#{params[:batch_action]}") and return true
+              redirect_to send("redirect_after_batch_action_#{params[:batch_action]}") and return
             end
           end
 

--- a/lib/godmin/resources/resource_controller.rb
+++ b/lib/godmin/resources/resource_controller.rb
@@ -1,11 +1,14 @@
 require "godmin/helpers/batch_actions"
 require "godmin/helpers/filters"
 require "godmin/helpers/tables"
+require "godmin/resources/resource_controller/batch_actions"
 
 module Godmin
   module Resources
     module ResourceController
       extend ActiveSupport::Concern
+
+      include BatchActions
 
       included do
         helper Godmin::Helpers::BatchActions
@@ -157,47 +160,6 @@ module Godmin
 
       def redirect_flash_message
         translate_scoped("flash.#{action_name}", resource: @resource.class.model_name.human)
-      end
-
-      concerning :BatchActions do
-        included do
-          prepend_before_action :perform_batch_action, only: :update
-        end
-
-        protected
-
-        def perform_batch_action
-          return unless params[:batch_action].present?
-
-          set_resource_service
-          set_resource_class
-
-          if authorization_enabled?
-            authorize(batch_action_records, "batch_action_#{params[:batch_action]}?")
-          end
-
-          if @resource_service.batch_action(params[:batch_action], batch_action_records)
-            flash[:notice] = translate_scoped(
-              "flash.batch_action", number_of_records: batch_action_ids.length,
-                                    resource: @resource_class.model_name.human(count: batch_action_ids.length)
-            )
-            flash[:updated_ids] = batch_action_ids
-
-            if respond_to?("redirect_after_batch_action_#{params[:batch_action]}", true)
-              redirect_to send("redirect_after_batch_action_#{params[:batch_action]}") and return
-            end
-          end
-
-          redirect_to :back
-        end
-
-        def batch_action_ids
-          @_batch_action_ids ||= params[:id].split(",").map(&:to_i)
-        end
-
-        def batch_action_records
-          @_batch_action_records ||= @resource_class.where(id: batch_action_ids)
-        end
       end
     end
   end

--- a/lib/godmin/resources/resource_controller/batch_actions.rb
+++ b/lib/godmin/resources/resource_controller/batch_actions.rb
@@ -28,7 +28,8 @@ module Godmin
             flash[:updated_ids] = batch_action_ids
 
             if respond_to?("redirect_after_batch_action_#{params[:batch_action]}", true)
-              redirect_to send("redirect_after_batch_action_#{params[:batch_action]}") and return
+              redirect_to send("redirect_after_batch_action_#{params[:batch_action]}")
+              return
             end
           end
 

--- a/lib/godmin/resources/resource_controller/batch_actions.rb
+++ b/lib/godmin/resources/resource_controller/batch_actions.rb
@@ -1,0 +1,48 @@
+module Godmin
+  module Resources
+    module ResourceController
+      module BatchActions
+        extend ActiveSupport::Concern
+
+        included do
+          prepend_before_action :perform_batch_action, only: :update
+        end
+
+        protected
+
+        def perform_batch_action
+          return unless params[:batch_action].present?
+
+          set_resource_service
+          set_resource_class
+
+          if authorization_enabled?
+            authorize(batch_action_records, "batch_action_#{params[:batch_action]}?")
+          end
+
+          if @resource_service.batch_action(params[:batch_action], batch_action_records)
+            flash[:notice] = translate_scoped(
+              "flash.batch_action", number_of_records: batch_action_ids.length,
+                                    resource: @resource_class.model_name.human(count: batch_action_ids.length)
+            )
+            flash[:updated_ids] = batch_action_ids
+
+            if respond_to?("redirect_after_batch_action_#{params[:batch_action]}", true)
+              redirect_to send("redirect_after_batch_action_#{params[:batch_action]}") and return
+            end
+          end
+
+          redirect_to :back
+        end
+
+        def batch_action_ids
+          @_batch_action_ids ||= params[:id].split(",").map(&:to_i)
+        end
+
+        def batch_action_records
+          @_batch_action_records ||= @resource_class.where(id: batch_action_ids)
+        end
+      end
+    end
+  end
+end

--- a/template.rb
+++ b/template.rb
@@ -230,15 +230,15 @@ def modify_article_service(namespace = nil)
       batch_action :destroy, confirm: true
 
       def batch_action_unpublish(articles)
-        articles.each { |a| a.update(published: false) }
+        articles.update_all(published: false)
       end
 
       def batch_action_publish(articles)
-        articles.each { |a| a.update(published: true) }
+        articles.update_all(published: true)
       end
 
       def batch_action_destroy(articles)
-        articles.each { |a| a.destroy }
+        articles.destroy_all
       end
 
       def per_page

--- a/test/dummy/admin/app/assets/javascripts/admin/application.js
+++ b/test/dummy/admin/app/assets/javascripts/admin/application.js
@@ -10,5 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require moment
 //= require godmin
 //= require_tree .

--- a/test/dummy/app/assets/javascripts/application.js
+++ b/test/dummy/app/assets/javascripts/application.js
@@ -10,5 +10,6 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require moment
 //= require godmin
 //= require_tree .

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
+  include Godmin::ApplicationController
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-
-  include Godmin::ApplicationController
 end

--- a/test/dummy/app/controllers/articles_controller.rb
+++ b/test/dummy/app/controllers/articles_controller.rb
@@ -1,3 +1,13 @@
 class ArticlesController < ApplicationController
   include Godmin::Resources::ResourceController
+
+  private
+
+  def redirect_after_batch_action_publish
+    articles_path(scope: :published)
+  end
+
+  def redirect_after_batch_action_unpublish
+    articles_path(scope: :unpublished)
+  end
 end

--- a/test/dummy/app/services/article_service.rb
+++ b/test/dummy/app/services/article_service.rb
@@ -6,4 +6,14 @@ class ArticleService
   attrs_for_form :title, :body, :published
 
   filter :title
+
+  def filter_title(articles, value)
+    articles.where(title: value)
+  end
+
+  batch_action :destroy
+
+  def batch_action_destroy(articles)
+    articles.each(&:destroy!)
+  end
 end

--- a/test/dummy/app/services/article_service.rb
+++ b/test/dummy/app/services/article_service.rb
@@ -5,6 +5,17 @@ class ArticleService
   attrs_for_show :id, :title, :body, :published
   attrs_for_form :title, :body, :published
 
+  scope :unpublished
+  scope :published
+
+  def scope_unpublished(articles)
+    articles.where(published: false)
+  end
+
+  def scope_published(articles)
+    articles.where(published: true)
+  end
+
   filter :title
 
   def filter_title(articles, value)
@@ -12,8 +23,18 @@ class ArticleService
   end
 
   batch_action :destroy
+  batch_action :publish
+  batch_action :unpublish
 
   def batch_action_destroy(articles)
     articles.destroy_all
+  end
+
+  def batch_action_publish(articles)
+    articles.update_all(published: true)
+  end
+
+  def batch_action_unpublish(articles)
+    articles.update_all(published: false)
   end
 end

--- a/test/dummy/app/services/article_service.rb
+++ b/test/dummy/app/services/article_service.rb
@@ -14,6 +14,6 @@ class ArticleService
   batch_action :destroy
 
   def batch_action_destroy(articles)
-    articles.each(&:destroy!)
+    articles.destroy_all
   end
 end

--- a/test/dummy/app/services/secret_article_service.rb
+++ b/test/dummy/app/services/secret_article_service.rb
@@ -1,9 +1,2 @@
 class SecretArticleService < ArticleService
-  include Godmin::Resources::ResourceService
-
-  attrs_for_index :id, :title, :published, :created_at
-  attrs_for_show :id, :title, :body, :published
-  attrs_for_form :title, :body, :published
-
-  filter :title
 end

--- a/test/dummy/db/migrate/20150717121532_create_articles.rb
+++ b/test/dummy/db/migrate/20150717121532_create_articles.rb
@@ -3,7 +3,7 @@ class CreateArticles < ActiveRecord::Migration
     create_table :articles do |t|
       t.string :title
       t.text :body
-      t.boolean :published
+      t.boolean :published, default: false
 
       t.timestamps null: false
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -23,9 +23,9 @@ ActiveRecord::Schema.define(version: 20150907133753) do
   create_table "articles", force: :cascade do |t|
     t.string   "title"
     t.text     "body"
-    t.boolean  "published"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.boolean  "published",  default: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
   end
 
 end

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -15,7 +15,8 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
     within "#actions" do
       click_link "Destroy"
     end
-    assert_equal articles_path, current_path
+
+    assert_equal 200, page.status_code
     assert page.has_no_content? "foo"
     assert page.has_no_content? "bar"
 

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -9,9 +9,7 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
 
     visit articles_path
 
-    all(:css, "[data-behavior~=batch-actions-checkbox]").each do |el|
-      el.set(true)
-    end
+    all("[data-behavior~=batch-actions-checkbox]").each(&:click)
     within "#actions" do
       click_link "Destroy"
     end
@@ -21,5 +19,33 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
     assert page.has_no_content? "bar"
 
     Capybara.use_default_driver
+  end
+
+  def test_batch_action_redirect
+    Capybara.current_driver = Capybara.javascript_driver
+
+    Article.create! title: "foo"
+
+    visit articles_path
+
+    all("[data-behavior~=batch-actions-checkbox]").each(&:click)
+    within "#actions" do
+      click_link "Publish"
+    end
+
+    assert_equal articles_path(scope: :published), current_path_with_params
+    assert_equal 200, page.status_code
+
+    Capybara.use_default_driver
+  end
+
+  private
+
+  def current_path_with_params
+    "#{current_uri.path}?#{current_uri.query}"
+  end
+
+  def current_uri
+    URI.parse(page.current_url)
   end
 end

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class BatchActionsTest < ActionDispatch::IntegrationTest
+  def test_batch_action
+    Article.create! title: "foo"
+    Article.create! title: "bar"
+
+    visit articles_path
+
+    all(:css, "[data-behavior~=batch-actions-checkbox]").each do |el|
+      el.set(true)
+    end
+    within "#actions" do
+      click_link "Destroy"
+    end
+    assert_not page.has_content? "foo"
+    assert_not page.has_content? "bar"
+  end
+end

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class BatchActionsTest < ActionDispatch::IntegrationTest
   def test_batch_action
+    Capybara.current_driver = :poltergeist
+
     Article.create! title: "foo"
     Article.create! title: "bar"
 
@@ -15,5 +17,7 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
     end
     assert_not page.has_content? "foo"
     assert_not page.has_content? "bar"
+
+    Capybara.use_default_driver
   end
 end

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class BatchActionsTest < ActionDispatch::IntegrationTest
   def test_batch_action
-    Capybara.current_driver = :poltergeist
+    Capybara.current_driver = Capybara.javascript_driver
 
     Article.create! title: "foo"
     Article.create! title: "bar"

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -15,8 +15,8 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
     within "#actions" do
       click_link "Destroy"
     end
-    assert_not page.has_content? "foo"
-    assert_not page.has_content? "bar"
+    assert page.has_no_content? "foo"
+    assert page.has_no_content? "bar"
 
     Capybara.use_default_driver
   end

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -15,6 +15,7 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
     within "#actions" do
       click_link "Destroy"
     end
+    assert_equal articles_path, current_path
     assert page.has_no_content? "foo"
     assert page.has_no_content? "bar"
 

--- a/test/integration/filters_test.rb
+++ b/test/integration/filters_test.rb
@@ -9,10 +9,12 @@ class FiltersTest < ActionDispatch::IntegrationTest
 
     fill_in "Title", with: "foo"
     click_button "Filter"
+    assert_equal 200, page.status_code
     assert page.has_content? "foo"
     assert page.has_no_content? "bar"
 
     click_link "Clear filter"
+    assert_equal 200, page.status_code
     assert page.has_content? "foo"
     assert page.has_content? "bar"
   end

--- a/test/integration/filters_test.rb
+++ b/test/integration/filters_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class FiltersTest < ActionDispatch::IntegrationTest
+  def test_filter
+    Article.create! title: "foo"
+    Article.create! title: "bar"
+
+    visit articles_path
+
+    fill_in "Title", with: "foo"
+    click_button "Filter"
+    assert page.has_content? "foo"
+    assert_not page.has_content? "bar"
+
+    click_link "Clear filter"
+    assert page.has_content? "foo"
+    assert page.has_content? "bar"
+  end
+end

--- a/test/integration/filters_test.rb
+++ b/test/integration/filters_test.rb
@@ -10,7 +10,7 @@ class FiltersTest < ActionDispatch::IntegrationTest
     fill_in "Title", with: "foo"
     click_button "Filter"
     assert page.has_content? "foo"
-    assert_not page.has_content? "bar"
+    assert page.has_no_content? "bar"
 
     click_link "Clear filter"
     assert page.has_content? "foo"

--- a/test/integration/scopes_test.rb
+++ b/test/integration/scopes_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ScopesTest < ActionDispatch::IntegrationTest
+  def test_scopes
+    Capybara.current_driver = Capybara.javascript_driver
+
+    Article.create! title: "foo"
+    Article.create! title: "bar"
+    Article.create! title: "baz", published: true
+
+    visit articles_path
+
+    assert page.has_content? "foo"
+    assert page.has_content? "bar"
+    assert page.has_no_content? "baz"
+
+    within "#scopes" do
+      click_link "Published"
+    end
+
+    assert page.has_no_content? "foo"
+    assert page.has_no_content? "bar"
+    assert page.has_content? "baz"
+  end
+end

--- a/test/integration/scopes_test.rb
+++ b/test/integration/scopes_test.rb
@@ -2,8 +2,6 @@ require "test_helper"
 
 class ScopesTest < ActionDispatch::IntegrationTest
   def test_scopes
-    Capybara.current_driver = Capybara.javascript_driver
-
     Article.create! title: "foo"
     Article.create! title: "bar"
     Article.create! title: "baz", published: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ CodeClimate::TestReporter.start
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
-require File.expand_path("../dummy/config/environment.rb",  __FILE__)
+require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require "rails/test_help"
 require "capybara/rails"
 require "capybara/poltergeist"
@@ -12,8 +12,8 @@ require "minitest/reporters"
 require "pry"
 
 # TODO: what to call these?
-require File.expand_path("../fakes/article.rb",  __FILE__)
-require File.expand_path("../fakes/article_service.rb",  __FILE__)
+require File.expand_path("../fakes/article.rb", __FILE__)
+require File.expand_path("../fakes/article_service.rb", __FILE__)
 
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(
   color: true
@@ -41,6 +41,8 @@ end
 # Forces all threads to share the same connection. This works on
 # Capybara because it starts the web server in a thread.
 ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+
+Capybara.javascript_driver = :poltergeist
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,6 +29,19 @@ if ActiveSupport::TestCase.method_defined?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
 end
 
+class ActiveRecord::Base
+  mattr_accessor :shared_connection
+  @@shared_connection = nil
+
+  def self.connection
+    @@shared_connection || retrieve_connection
+  end
+end
+
+# Forces all threads to share the same connection. This works on
+# Capybara because it starts the web server in a thread.
+ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
 require "capybara/rails"
+require "capybara/poltergeist"
 require "minitest/reporters"
 require "pry"
 


### PR DESCRIPTION
Fixes #151 

This PR changes batch actions to take an active record relation object instead of an array. It also extracts the batch action part of the resource controller into its own module. Lastly, it adds a bunch of integration tests for batch actions, scopes and filters.

- [x] Have batch actions take a relation instead of an array
- [x] Have the batch action policy method take a relation instead of an instance
- [x] Enable poltergeist capybara adapter for javascript tests
- [x] Add tests for batch actions
- [x] Add tests for batch action redirects
- [ ] ~~Add tests for batch action authorization~~
- [x] Add tests for scopes
- [x] Add tests for filters
- [x] Extract the batch action module into its own file
- [x] Fix randomly failing order column tests
- [x] Update readme
- [x] Update sandbox template