### PR TITLE
Removes hidden field for multiselect filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Features
 - Increased batch action checkbox click area (https://github.com/varvet/godmin/pull/183)
 - Adds titles to action links (https://github.com/varvet/godmin/pull/185)
 
+Bug fixes:
+- Fixes so an empty string is not sent for multiselect filters (https://github.com/varvet/godmin/pull/169)
+
 Other
 - Fixes a deprecation warning on Rails 4.2.5.1 (https://github.com/varvet/godmin/pull/188)
 - Adds caching partial overrides to increase table rendering speed (https://github.com/varvet/godmin/pull/184)

--- a/lib/godmin/helpers/filters.rb
+++ b/lib/godmin/helpers/filters.rb
@@ -47,7 +47,9 @@ module Godmin
 
       def multiselect_filter_field(name, options, html_options = {})
         filter_select(
-          name, options, {
+          name, {
+            include_hidden: false
+          }.deep_merge(options), {
             name: "filter[#{name}][]",
             multiple: true,
             data: {
@@ -78,14 +80,14 @@ module Godmin
           fail "A collection proc must be specified for select filters"
         end
 
-        collection = options[:collection].call
+        collection = options.delete(:collection).call
 
         choices =
           if collection.is_a? ActiveRecord::Relation
             @template.options_from_collection_for_select(
               collection,
-              options[:option_value],
-              options[:option_text],
+              options.delete(:option_value),
+              options.delete(:option_text),
               selected: default_filter_value(name)
             )
           else
@@ -101,7 +103,7 @@ module Godmin
             label: @template.translate_scoped("filters.labels.#{name}", default: name.to_s.titleize),
             include_hidden: true,
             include_blank: true
-          }, {
+          }.deep_merge(options), {
             data: { behavior: "select-box" }
           }.deep_merge(html_options)
         )

--- a/lib/godmin/helpers/filters.rb
+++ b/lib/godmin/helpers/filters.rb
@@ -77,8 +77,13 @@ module Godmin
 
       def filter_select(name, options, html_options)
         unless options[:collection].is_a? Proc
-          fail "A collection proc must be specified for select filters"
+          raise "A collection proc must be specified for select filters"
         end
+
+        # We need to dup this here because we later delete some properties
+        # from the hash. We should consider adding an additional options
+        # param to separate filter params from select tag params.
+        options = options.dup
 
         collection = options.delete(:collection).call
 

--- a/test/dummy/app/services/article_service.rb
+++ b/test/dummy/app/services/article_service.rb
@@ -9,9 +9,14 @@ class ArticleService
     resources.joins(:admin_users).order("admin_users.email #{direction}")
   end
 
+  scope :all
   scope :unpublished
   scope :published
   scope :no_batch_actions
+
+  def scope_all(articles)
+    articles
+  end
 
   def scope_unpublished(articles)
     articles.where(published: false)
@@ -26,9 +31,14 @@ class ArticleService
   end
 
   filter :title
+  filter :status, as: :select, collection: -> { [["Published", :published], ["Unpublished", :unpublished]] }
 
   def filter_title(articles, value)
     articles.where(title: value)
+  end
+
+  def filter_status(articles, value)
+    articles.where(published: value == "published")
   end
 
   batch_action :publish, except: [:published, :no_batch_actions]

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -26,7 +26,7 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
 
     Article.create! title: "foo"
 
-    visit articles_path
+    visit articles_path(scope: :unpublished)
 
     all("[data-behavior~=batch-actions-checkbox]").each(&:click)
     within "#actions" do
@@ -44,7 +44,7 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
 
     Article.create! title: "foo"
 
-    visit articles_path
+    visit articles_path(scope: :unpublished)
 
     all("[data-behavior~=batch-actions-checkbox]").each(&:click)
     within "#actions" do

--- a/test/integration/filters_test.rb
+++ b/test/integration/filters_test.rb
@@ -18,4 +18,19 @@ class FiltersTest < ActionDispatch::IntegrationTest
     assert page.has_content? "foo"
     assert page.has_content? "bar"
   end
+
+  def test_select_filter
+    Article.create! title: "foo", published: true
+    Article.create! title: "bar"
+
+    visit articles_path
+
+    within "#filters" do
+      find("select").select("Published")
+    end
+    click_button "Filter"
+    assert_equal 200, page.status_code
+    assert page.has_content? "foo"
+    assert page.has_no_content? "bar"
+  end
 end

--- a/test/integration/scopes_test.rb
+++ b/test/integration/scopes_test.rb
@@ -6,7 +6,7 @@ class ScopesTest < ActionDispatch::IntegrationTest
     Article.create! title: "bar"
     Article.create! title: "baz", published: true
 
-    visit articles_path
+    visit articles_path(scope: :unpublished)
 
     assert page.has_content? "foo"
     assert page.has_content? "bar"

--- a/test/lib/godmin/helpers/filters_test.rb
+++ b/test/lib/godmin/helpers/filters_test.rb
@@ -13,13 +13,36 @@ module Godmin
         end
       end
 
-      # TODO: actually implement this test properly, apparently
-      # assert_select can be used if the helper output is parsed
-      # with HTML::Document first...
-      def test_string_filter_field
-        form = filter_form url: "/" do |f|
+      def test_string_renders_as_string
+        @output_buffer = filter_form url: "/" do |f|
           f.filter_field :foo, as: :string
         end
+
+        assert_select "input[type=text][name=?]", "filter[foo]", 1, "No text input found with name foo"
+      end
+
+      def test_string_filter_field_renders_text_field
+        @output_buffer = filter_form url: "/" do |f|
+          f.string_filter_field :foo, {}, value: "Foobar"
+        end
+
+        assert_select "label[for=foo]", 1, "No label was found"
+        assert_select "input[type=text][name=?]", "filter[foo]", 1, "No text input found with name foo" do |element|
+          assert_equal "Foo", element.attr("placeholder").text
+          assert_equal "Foobar", element.attr("value").text
+        end
+      end
+
+      def test_multiselect_filter_field_includes_no_hidden
+        @output_buffer = filter_form url: "/" do |f|
+          f.multiselect_filter_field :foo, collection: -> { %w(Foo Bar) }
+        end
+
+        assert_select "label[for=foo]", 1, "No label was found"
+        assert_select "select[name=?]", "filter[foo][]", 1, "No text input found with name foo" do
+          assert_select "option", 3
+        end
+        assert_select "input[type=hidden][name=?]", "filter[foo][]", 0
       end
     end
   end

--- a/test/lib/godmin/helpers/filters_test.rb
+++ b/test/lib/godmin/helpers/filters_test.rb
@@ -13,17 +13,9 @@ module Godmin
         end
       end
 
-      def test_string_renders_as_string
+      def test_filter_field_as_string
         @output_buffer = filter_form url: "/" do |f|
-          f.filter_field :foo, as: :string
-        end
-
-        assert_select "input[type=text][name=?]", "filter[foo]", 1, "No text input found with name foo"
-      end
-
-      def test_string_filter_field_renders_text_field
-        @output_buffer = filter_form url: "/" do |f|
-          f.string_filter_field :foo, {}, value: "Foobar"
+          f.filter_field :foo, { as: :string }, value: "Foobar"
         end
 
         assert_select "label[for=foo]", 1, "No label was found"
@@ -33,15 +25,23 @@ module Godmin
         end
       end
 
-      def test_multiselect_filter_field_includes_no_hidden
+      def test_filter_field_as_multiselect
         @output_buffer = filter_form url: "/" do |f|
-          f.multiselect_filter_field :foo, collection: -> { %w(Foo Bar) }
+          f.filter_field :foo, as: :multiselect, collection: -> { %w(Foo Bar) }
         end
 
         assert_select "label[for=foo]", 1, "No label was found"
-        assert_select "select[name=?]", "filter[foo][]", 1, "No text input found with name foo" do
+        assert_select "select[name=?]", "filter[foo][]", 1, "No select found with name foo" do
           assert_select "option", 3
         end
+        assert_select "input[type=hidden][name=?]", "filter[foo][]", 0
+      end
+
+      def test_filter_field_as_multiselect_includes_no_hidden_field
+        @output_buffer = filter_form url: "/" do |f|
+          f.filter_field :foo, as: :multiselect, collection: -> { %w(Foo Bar) }
+        end
+
         assert_select "input[type=hidden][name=?]", "filter[foo][]", 0
       end
     end

--- a/test/lib/godmin/helpers/filters_test.rb
+++ b/test/lib/godmin/helpers/filters_test.rb
@@ -25,6 +25,17 @@ module Godmin
         end
       end
 
+      def test_filter_field_as_select
+        @output_buffer = filter_form url: "/" do |f|
+          f.filter_field :foo, as: :select, collection: -> { %w(Foo Bar) }
+        end
+
+        assert_select "label[for=foo]", 1, "No label was found"
+        assert_select "select[name=?]", "filter[foo]", 1, "No select found with name foo" do
+          assert_select "option", 3
+        end
+      end
+
       def test_filter_field_as_multiselect
         @output_buffer = filter_form url: "/" do |f|
           f.filter_field :foo, as: :multiselect, collection: -> { %w(Foo Bar) }
@@ -34,14 +45,6 @@ module Godmin
         assert_select "select[name=?]", "filter[foo][]", 1, "No select found with name foo" do
           assert_select "option", 3
         end
-        assert_select "input[type=hidden][name=?]", "filter[foo][]", 0
-      end
-
-      def test_filter_field_as_multiselect_includes_no_hidden_field
-        @output_buffer = filter_form url: "/" do |f|
-          f.filter_field :foo, as: :multiselect, collection: -> { %w(Foo Bar) }
-        end
-
         assert_select "input[type=hidden][name=?]", "filter[foo][]", 0
       end
     end


### PR DESCRIPTION
Fixes: #161

- [x] Implement
- [x] Changelog
- [x] Tests

We should probably add some tests for this stuff but I'd like some comments on this first... I changed so we now pass along the options hash, merging it along the way like we do with `html_options`. 

I guess we can also remove this code now?
https://github.com/varvet/godmin/blob/master/lib/godmin/resources/resource_service/filters.rb#L23

That shouldn't happen now since if the user does not select anything in the filter, nothing will be sent by the browser.