### PR TITLE
Fix FormBuilder#association to apply options

### DIFF
--- a/lib/godmin/helpers/forms.rb
+++ b/lib/godmin/helpers/forms.rb
@@ -27,7 +27,7 @@ module Godmin
       def association(attribute, options = {})
         case association_type(attribute)
         when :belongs_to
-          select "#{attribute}_id", association_collection_for_select(attribute), {}, data: { behavior: "select-box" }
+          select "#{attribute}_id", association_collection_for_select(attribute), options, data: { behavior: "select-box" }
         else
           input(attribute, options)
         end


### PR DESCRIPTION
This commit fixes Godmin::FormBuilders::FormBuilder#association helper method to apply taken options for #select method.