### PR TITLE
Added option to skip updating navigation links partial

### DIFF
--- a/lib/generators/godmin/resource/resource_generator.rb
+++ b/lib/generators/godmin/resource/resource_generator.rb
@@ -2,12 +2,13 @@ require "godmin/generators/named_base"
 
 class Godmin::ResourceGenerator < Godmin::Generators::NamedBase
   argument :attributes, type: :array, default: [], banner: "attribute attribute"
-
+  class_option :"skip-navigation", :type => :boolean, :default => false, :description => "Skips extending navigation partial with new link"
   def add_route
     route "resources :#{file_name.pluralize}"
   end
 
   def add_navigation
+    return if options["skip-navigation"]
     append_to_file File.join("app/views", namespaced_path, "shared/_navigation.html.erb") do
       <<-END.strip_heredoc
         <%= navbar_item #{class_name} %>


### PR DESCRIPTION
Hey!

I ran into this issue where I wanted to use godmin inside an engine that does not provide it's own `views/shared/_navigation.html.erb` and trying to use the `godmin:resource` generator always failed at trying to manipulate the non-existing file. 

So basically I've just added an option to the generator in order to skip that step entierly. 
The default behavior should be unaffected. 