### PR TITLE
Turn off ruby warnings by default in rake test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "lib"
   t.libs << "test"
   t.pattern = "test/**/*_test.rb"
+  t.warning = false
   t.verbose = false
 end
 


### PR DESCRIPTION
Since 1.11 rake outputs warnings by default. We should suppress them since they make CI fail and what not...

The issue is not if it complains about Godmin related code, but it seems to warn about all the dependency code as well.

Example:
https://travis-ci.org/varvet/godmin/jobs/116864598