### PR TITLE
Hide batch action toggle when no batch action available

### DIFF
--- a/app/views/godmin/resource/_batch_actions.html.erb
+++ b/app/views/godmin/resource/_batch_actions.html.erb
@@ -1,4 +1,4 @@
-<% if @resource_service.batch_action_map.present? %>
+<% if @resource_service.include_batch_actions? %>
   <%= link_to translate_scoped("batch_actions.buttons.select_all"), "#", class: "btn btn-default",
     data: { behavior: "batch-actions-select batch-actions-select-all" } %>
   <%= link_to translate_scoped("batch_actions.buttons.deselect_all"), "#", class: "btn btn-default hidden",

--- a/app/views/godmin/resource/_table.html.erb
+++ b/app/views/godmin/resource/_table.html.erb
@@ -2,7 +2,7 @@
   <table class="table table-bordered table-hover">
     <thead>
       <tr>
-        <% if @resource_service.batch_action_map.present? %>
+        <% if @resource_service.include_batch_actions? %>
           <th></th>
         <% end %>
         <% @resource_service.attrs_for_index.each do |attr| %>
@@ -16,7 +16,7 @@
     <tbody>
       <% @resources.each do |resource| %>
         <tr data-resource-id="<%= resource.id %>" class="<%= "highlight" if flash[:updated_ids] && flash[:updated_ids].include?(resource.id) %>">
-          <% if @resource_service.batch_action_map.present? %>
+          <% if @resource_service.include_batch_actions? %>
             <td align="center" data-behavior="batch-actions-checkbox-container">
               <%= check_box_tag "batch_action[items][#{resource.id}]", nil, nil,
                 data: { behavior: "batch-actions-checkbox" } %>

--- a/lib/godmin/helpers/batch_actions.rb
+++ b/lib/godmin/helpers/batch_actions.rb
@@ -2,7 +2,7 @@ module Godmin
   module Helpers
     module BatchActions
       def batch_action_link(name, options)
-        return unless include_batch_action_link?(options)
+        return unless @resource_service.include_batch_action?(name)
 
         link_to(
           translate_scoped("batch_actions.labels.#{name}", default: name.to_s.titleize),
@@ -15,14 +15,6 @@ module Godmin
             value: name
           }
         )
-      end
-
-      private
-
-      def include_batch_action_link?(options)
-        (options[:only].nil? && options[:except].nil?) ||
-          (options[:only] && options[:only].include?(@resource_service.scope.to_sym)) ||
-          (options[:except] && !options[:except].include?(@resource_service.scope.to_sym))
       end
     end
   end

--- a/lib/godmin/resources/resource_service/batch_actions.rb
+++ b/lib/godmin/resources/resource_service/batch_actions.rb
@@ -19,6 +19,20 @@ module Godmin
           batch_action_map.key?(action.to_sym)
         end
 
+        def include_batch_action?(action)
+          options = batch_action_map[action.to_sym]
+
+          (options[:only].nil? && options[:except].nil?) ||
+            (options[:only] && options[:only].include?(scope.to_sym)) ||
+            (options[:except] && !options[:except].include?(scope.to_sym))
+        end
+
+        def include_batch_actions?
+          batch_action_map.keys.any? do |action|
+            include_batch_action?(action)
+          end
+        end
+
         module ClassMethods
           def batch_action_map
             @batch_action_map ||= {}

--- a/test/dummy/app/services/article_service.rb
+++ b/test/dummy/app/services/article_service.rb
@@ -26,9 +26,9 @@ class ArticleService
     articles.where(title: value)
   end
 
+  batch_action :publish, except: [:published]
+  batch_action :unpublish, except: [:published, :unpublished]
   batch_action :destroy
-  batch_action :publish
-  batch_action :unpublish
 
   def batch_action_destroy(articles)
     articles.destroy_all

--- a/test/dummy/app/services/article_service.rb
+++ b/test/dummy/app/services/article_service.rb
@@ -11,6 +11,7 @@ class ArticleService
 
   scope :unpublished
   scope :published
+  scope :no_batch_actions
 
   def scope_unpublished(articles)
     articles.where(published: false)
@@ -20,15 +21,19 @@ class ArticleService
     articles.where(published: true)
   end
 
+  def scope_no_batch_actions(articles)
+    articles
+  end
+
   filter :title
 
   def filter_title(articles, value)
     articles.where(title: value)
   end
 
-  batch_action :publish, except: [:published]
-  batch_action :unpublish, except: [:published, :unpublished]
-  batch_action :destroy, except: [:published]
+  batch_action :publish, except: [:published, :no_batch_actions]
+  batch_action :unpublish, except: [:unpublished, :no_batch_actions]
+  batch_action :destroy, except: [:no_batch_actions]
 
   def batch_action_destroy(articles)
     articles.destroy_all

--- a/test/dummy/app/services/article_service.rb
+++ b/test/dummy/app/services/article_service.rb
@@ -28,7 +28,7 @@ class ArticleService
 
   batch_action :publish, except: [:published]
   batch_action :unpublish, except: [:published, :unpublished]
-  batch_action :destroy
+  batch_action :destroy, except: [:published]
 
   def batch_action_destroy(articles)
     articles.destroy_all

--- a/test/fakes/article_service.rb
+++ b/test/fakes/article_service.rb
@@ -17,7 +17,7 @@ module Fakes
     filter :tags, as: :multiselect, collection: %w(Apple Banana)
 
     batch_action :unpublish
-    batch_action :publish, confirm: true, only: :unpublished, except: :published
+    batch_action :publish, confirm: true, only: [:unpublished], except: [:published]
 
     def initialize(*)
       super

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -39,6 +39,35 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
     Capybara.use_default_driver
   end
 
+  def test_batch_action_scopes
+    Capybara.current_driver = Capybara.javascript_driver
+
+    Article.create! title: "foo"
+
+    visit articles_path
+
+    all("[data-behavior~=batch-actions-checkbox]").each(&:click)
+    within "#actions" do
+      assert page.has_content? "Publish"
+      assert page.has_no_content? "Unpublish"
+    end
+
+    Capybara.use_default_driver
+  end
+
+  def test_batch_action_scopes_when_no_batch_actions
+    Capybara.current_driver = Capybara.javascript_driver
+
+    Article.create! title: "foo"
+
+    visit articles_path(scope: :unpublished)
+
+    assert_not page.has_content? "Select all"
+    assert_not page.has_css? "[data-behavior~=batch-actions-checkbox]"
+
+    Capybara.use_default_driver
+  end
+
   private
 
   def current_path_with_params

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -60,7 +60,7 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
 
     Article.create! title: "foo"
 
-    visit articles_path(scope: :published)
+    visit articles_path(scope: :no_batch_actions)
 
     assert page.has_no_content?("Select all")
     assert page.has_no_css?("[data-behavior~=batch-actions-checkbox]")

--- a/test/integration/batch_actions_test.rb
+++ b/test/integration/batch_actions_test.rb
@@ -60,10 +60,10 @@ class BatchActionsTest < ActionDispatch::IntegrationTest
 
     Article.create! title: "foo"
 
-    visit articles_path(scope: :unpublished)
+    visit articles_path(scope: :published)
 
-    assert_not page.has_content? "Select all"
-    assert_not page.has_css? "[data-behavior~=batch-actions-checkbox]"
+    assert page.has_no_content?("Select all")
+    assert page.has_no_css?("[data-behavior~=batch-actions-checkbox]")
 
     Capybara.use_default_driver
   end

--- a/test/lib/godmin/resources/resource_service/batch_actions_test.rb
+++ b/test/lib/godmin/resources/resource_service/batch_actions_test.rb
@@ -31,7 +31,7 @@ module Godmin
       end
 
       def test_batch_action_map_with_custom_options
-        expected_batch_action_map = { only: :unpublished, except: :published, confirm: true }
+        expected_batch_action_map = { only: [:unpublished], except: [:published], confirm: true }
         assert_equal expected_batch_action_map, @article_service.batch_action_map[:publish]
       end
     end


### PR DESCRIPTION
Fixes #179 

If a particular scope has no batch actions, hide the toggle and the check boxes from the table. 

I extracted the logic from the helper to the service object, but there are still no unit tests for those methods. I did add some integration tests though. I feel our test fakes are getting a bit complicated, it's difficult to come up with a scenario that fits all the different cases. Perhaps we should move away from using a single fake across many test scenarios and just create whatever we need for each test? 

@Linuus ping