### PR TITLE
Change color of remove buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ### Unreleased
+Features
+- Change color of remove buttons, so they're not grabbing all the attention
+
 Bug fixes
 - Fix permitted params in sessions controller to work with models other than `AdminUser` (https://github.com/varvet/godmin/pull/210)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 Features
-- Change color of remove buttons, so they're not grabbing all the attention
+- Change color of remove buttons, so they're not grabbing all the attention (https://github.com/varvet/godmin/pull/212)
 
 Bug fixes
 - Fix permitted params in sessions controller to work with models other than `AdminUser` (https://github.com/varvet/godmin/pull/210)

--- a/app/views/godmin/resource/columns/_actions.html.erb
+++ b/app/views/godmin/resource/columns/_actions.html.erb
@@ -20,7 +20,7 @@
       translate_scoped("actions.destroy"),
       resource,
       method: :delete,
-      class: "btn btn-danger",
+      class: "btn btn-default",
       title: translate_scoped("actions.destroy_title", resource: resource),
       data: { confirm: translate_scoped("actions.confirm_message") }
     ) %>


### PR DESCRIPTION
We've gotten some feedback that the color of the remove buttons (red) is a bit eye grabbing. It's basically the only element that stands out. I agree!