### PR TITLE
Allow skipping authorization per action

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,16 @@ end
 
 The admin section is now authenticated using Devise.
 
+### Disable authentication
+
+If you want to disable authentication for a single controller or controller action, use the following `before_action`:
+
+```ruby
+class ArticlesController < ApplicationController
+  prepend_before_action :disable_authentication
+end
+```
+
 ## Authorization
 
 In order to enable authorization, authentication must first be enabled. See the previous section. The Godmin authorization system is heavily inspired by [Pundit](https://github.com/elabs/pundit) and implements the same interface.
@@ -837,6 +847,16 @@ class ArticlePolicy < Godmin::Authorization::Policy
   def batch_action_destroy?
     record.all? { |r| r.user_id == user.id }
   end
+end
+```
+
+### Disable authorization
+
+If you want to disable authorization for a single controller or controller action, use the following `before_action`:
+
+```ruby
+class ArticlesController < ApplicationController
+  prepend_before_action :disable_authorization
 end
 ```
 

--- a/lib/godmin/application_controller.rb
+++ b/lib/godmin/application_controller.rb
@@ -20,8 +20,6 @@ module Godmin
       helper_method :engine_wrapper
 
       before_action :append_view_paths
-      before_action :enable_authentication
-      before_action :enable_authorization
 
       layout "godmin/application"
     end
@@ -49,20 +47,20 @@ module Godmin
       append_view_path Godmin::Resolver.resolvers(controller_path, engine_wrapper)
     end
 
-    def enable_authentication
-      @_enable_authentication = true
+    def disable_authentication
+      @_disable_authentication = true
     end
 
-    def enable_authorization
-      @_enable_authorization = true
+    def disable_authorization
+      @_disable_authorization = true
     end
 
     def authentication_enabled?
-      @_enable_authentication && singleton_class.include?(Godmin::Authentication)
+      !@_disable_authentication && singleton_class.include?(Godmin::Authentication)
     end
 
     def authorization_enabled?
-      @_enable_authorization && singleton_class.include?(Godmin::Authorization)
+      !@_disable_authorization && singleton_class.include?(Godmin::Authorization)
     end
   end
 end

--- a/lib/godmin/application_controller.rb
+++ b/lib/godmin/application_controller.rb
@@ -20,6 +20,8 @@ module Godmin
       helper_method :engine_wrapper
 
       before_action :append_view_paths
+      before_action :enable_authentication
+      before_action :enable_authorization
 
       layout "godmin/application"
     end
@@ -47,12 +49,20 @@ module Godmin
       append_view_path Godmin::Resolver.resolvers(controller_path, engine_wrapper)
     end
 
+    def enable_authentication
+      @_enable_authentication = true
+    end
+
+    def enable_authorization
+      @_enable_authorization = true
+    end
+
     def authentication_enabled?
-      singleton_class.include?(Godmin::Authentication)
+      @_enable_authentication && singleton_class.include?(Godmin::Authentication)
     end
 
     def authorization_enabled?
-      singleton_class.include?(Godmin::Authorization)
+      @_enable_authorization && singleton_class.include?(Godmin::Authorization)
     end
   end
 end

--- a/lib/godmin/authentication.rb
+++ b/lib/godmin/authentication.rb
@@ -14,20 +14,19 @@ module Godmin
 
     def authenticate
       return unless authentication_enabled?
+      return if admin_user_signed_in?
+      return if controller_name == "sessions"
 
-      unless admin_user_signed_in? || controller_name == "sessions"
-        redirect_to new_session_path
-      end
+      redirect_to new_session_path
     end
 
-    def admin_user_class
-      raise NotImplementedError, "Must define the admin user class"
-    end
+    def admin_user_class; end
 
     def admin_user
-      if session[:admin_user_id]
-        @admin_user ||= admin_user_class.find_by(id: session[:admin_user_id])
-      end
+      return unless admin_user_class
+      return unless session[:admin_user_id]
+
+      @_admin_user ||= admin_user_class.find_by(id: session[:admin_user_id])
     end
 
     def admin_user_signed_in?

--- a/lib/godmin/authentication.rb
+++ b/lib/godmin/authentication.rb
@@ -6,13 +6,15 @@ module Godmin
     extend ActiveSupport::Concern
 
     included do
-      before_action :authenticate_admin_user
+      before_action :authenticate
 
       helper_method :admin_user
       helper_method :admin_user_signed_in?
     end
 
-    def authenticate_admin_user
+    def authenticate
+      return unless authentication_enabled?
+
       unless admin_user_signed_in? || controller_name == "sessions"
         redirect_to new_session_path
       end

--- a/lib/godmin/authentication.rb
+++ b/lib/godmin/authentication.rb
@@ -15,7 +15,6 @@ module Godmin
     def authenticate
       return unless authentication_enabled?
       return if admin_user_signed_in?
-      return if controller_name == "sessions"
 
       redirect_to new_session_path
     end

--- a/lib/godmin/authentication/sessions_controller.rb
+++ b/lib/godmin/authentication/sessions_controller.rb
@@ -5,6 +5,7 @@ module Godmin
 
       included do
         layout "godmin/login"
+        prepend_before_action :disable_authentication
       end
 
       def new

--- a/test/dummy/app/controllers/another_admin_sessions_controller.rb
+++ b/test/dummy/app/controllers/another_admin_sessions_controller.rb
@@ -2,7 +2,7 @@ class AnotherAdminSessionsController < ApplicationController
   include Godmin::Authentication::SessionsController
   include Godmin::Authentication
 
-  skip_before_action :authenticate_admin_user
+  skip_before_action :enable_authentication
 
   def admin_user_class
     AnotherAdminUser

--- a/test/dummy/app/controllers/another_admin_sessions_controller.rb
+++ b/test/dummy/app/controllers/another_admin_sessions_controller.rb
@@ -2,7 +2,7 @@ class AnotherAdminSessionsController < ApplicationController
   include Godmin::Authentication::SessionsController
   include Godmin::Authentication
 
-  skip_before_action :enable_authentication
+  prepend_before_action :disable_authentication
 
   def admin_user_class
     AnotherAdminUser

--- a/test/dummy/app/controllers/another_admin_sessions_controller.rb
+++ b/test/dummy/app/controllers/another_admin_sessions_controller.rb
@@ -2,8 +2,6 @@ class AnotherAdminSessionsController < ApplicationController
   include Godmin::Authentication::SessionsController
   include Godmin::Authentication
 
-  prepend_before_action :disable_authentication
-
   def admin_user_class
     AnotherAdminUser
   end


### PR DESCRIPTION
This PR Fixes #226. It allows skipping authorization per action. Changed from the suggested `skip_before_action :enable_authentication` to `prepend_before_action :disable_authentication`.

- [x] Implement disable functions for authentication and authorization
- [x] Update readme