### PR TITLE
[WIP] New filter objects

### DIFF
--- a/app/views/godmin/filters/_boolean.html.erb
+++ b/app/views/godmin/filters/_boolean.html.erb
@@ -1,0 +1,7 @@
+<%
+# Local variables:
+#   `form` is the filter form object.
+#   `filter` is the filter being rendered
+%>
+
+<%= form.select_filter_field(filter) %>

--- a/app/views/godmin/filters/_multi_select.html.erb
+++ b/app/views/godmin/filters/_multi_select.html.erb
@@ -1,0 +1,7 @@
+<%
+# Local variables:
+#   `form` is the filter form object.
+#   `filter` is the filter being rendered
+%>
+
+<%= form.multiselect_filter_field(filter) %>

--- a/app/views/godmin/filters/_select.html.erb
+++ b/app/views/godmin/filters/_select.html.erb
@@ -1,0 +1,7 @@
+<%
+# Local variables:
+#   `form` is the filter form object.
+#   `filter` is the filter being rendered
+%>
+
+<%= form.select_filter_field(filter) %>

--- a/app/views/godmin/filters/_string.html.erb
+++ b/app/views/godmin/filters/_string.html.erb
@@ -1,0 +1,7 @@
+<%
+# Local variables:
+#  `form` is the filter form object.
+#   `filter` is the filter being rendered
+%>
+
+<%= form.string_filter_field(filter) %>

--- a/app/views/godmin/resource/_filters.html.erb
+++ b/app/views/godmin/resource/_filters.html.erb
@@ -1,14 +1,12 @@
-<% if @resource_service.filter_map.present? %>
+<% if @resource_service.filters.present? %>
   <div id="filters" class="panel panel-default">
     <div class="panel-body">
       <%= filter_form do |f| %>
         <%= f.hidden_field :scope, value: params[:scope] %>
         <%= f.hidden_field :order, value: params[:order] %>
 
-        <% @resource_service.filter_map.each do |name, options| %>
-          <%= partial_override "#{controller_path}/filters/#{name}", f: f, name: name, options: options do %>
-            <%= f.filter_field(name, options) %>
-          <% end %>
+        <% @resource_service.filters.each do |_name, filter| %>
+          <%= render partial: filter, locals: { form: f, filter: filter } %>
         <% end %>
 
         <div class="form-group pull-right">

--- a/lib/godmin/filter/base.rb
+++ b/lib/godmin/filter/base.rb
@@ -1,0 +1,22 @@
+module Godmin
+  module Filter
+    class Base
+      attr_reader :identifier, :column
+
+      def initialize(identifier, column: identifier, **)
+        @identifier = identifier
+        @column = column
+      end
+
+      def to_partial_path
+        "filters/#{class_name}"
+      end
+
+      protected
+
+      def class_name
+        self.class.to_s.split("::").last.underscore
+      end
+    end
+  end
+end

--- a/lib/godmin/filter/boolean.rb
+++ b/lib/godmin/filter/boolean.rb
@@ -1,16 +1,15 @@
 module Godmin
   module Filter
-    class Boolean < Base
+    class Boolean < Select
       attr_reader :collection
 
-      def initialize(identifier, collection: [["True", 1], ["False", 0]], **)
+      def initialize(identifier, true_label: "True", false_label: "False", **)
         super
-        @collection = collection
+        @collection = [[true_label, 1], [false_label, 0]]
       end
 
-      def call(value, scope)
-        value = value == "0" ? false : true
-        scope.where(column => value)
+      def call(resources, value)
+        super(resources, value == "1")
       end
     end
   end

--- a/lib/godmin/filter/boolean.rb
+++ b/lib/godmin/filter/boolean.rb
@@ -1,0 +1,17 @@
+module Godmin
+  module Filter
+    class Boolean < Base
+      attr_reader :collection
+
+      def initialize(identifier, collection: [["True", 1], ["False", 0]], **)
+        super
+        @collection = collection
+      end
+
+      def call(value, scope)
+        value = value == "0" ? false : true
+        scope.where(column => value)
+      end
+    end
+  end
+end

--- a/lib/godmin/filter/multi_select.rb
+++ b/lib/godmin/filter/multi_select.rb
@@ -1,0 +1,6 @@
+module Godmin
+  module Filter
+    class MultiSelect < Select
+    end
+  end
+end

--- a/lib/godmin/filter/select.rb
+++ b/lib/godmin/filter/select.rb
@@ -1,0 +1,18 @@
+module Godmin
+  module Filter
+    class Select < Base
+      attr_reader :collection, :option_text, :option_value
+
+      def initialize(identifier, collection: [], option_text: :to_s, option_value: :id, **)
+        super
+        @collection = collection
+        @option_text = option_text
+        @option_value = option_value
+      end
+
+      def call(resources, value)
+        resources.where(column => value)
+      end
+    end
+  end
+end

--- a/lib/godmin/filter/string.rb
+++ b/lib/godmin/filter/string.rb
@@ -8,7 +8,7 @@ module Godmin
         @wildcard = wildcard
       end
 
-      def call(value, resources)
+      def call(resources, value)
         if wildcard == :none
           resources.where(column => value)
         else

--- a/lib/godmin/filter/string.rb
+++ b/lib/godmin/filter/string.rb
@@ -1,0 +1,33 @@
+module Godmin
+  module Filter
+    class String < Base
+      attr_reader :wildcard
+
+      def initialize(identifier, wildcard: :none, **)
+        super
+        @wildcard = wildcard
+      end
+
+      def call(value, resources)
+        if wildcard == :none
+          resources.where(column => value)
+        else
+          resources.where("#{column} LIKE ?", wildcard_query(value))
+        end
+      end
+
+      private
+
+      def wildcard_query(value)
+        case wildcard
+        when :pre
+          "%#{value}"
+        when :post
+          "#{value}%"
+        when :both
+          "%#{value}%"
+        end
+      end
+    end
+  end
+end

--- a/lib/godmin/helpers/filters.rb
+++ b/lib/godmin/helpers/filters.rb
@@ -11,17 +11,6 @@ module Godmin
 
   module FormBuilders
     class FilterFormBuilder < BootstrapForm::FormBuilder
-      # def filter_field(name, options, html_options = {})
-      #   case options[:as]
-      #   when :string
-      #     string_filter_field(name, options, html_options)
-      #   when :select
-      #     select_filter_field(name, options, html_options)
-      #   when :multiselect
-      #     multiselect_filter_field(name, options, html_options)
-      #   end
-      # end
-
       def string_filter_field(filter, html_options = {})
         text_field(
           filter.identifier, {
@@ -47,7 +36,7 @@ module Godmin
 
       def multiselect_filter_field(filter, options = {}, html_options = {})
         filter_select(
-          filter.identifier, {
+          filter, {
             include_hidden: false
           }.deep_merge(options), {
             name: "filter[#{filter.identifier}][]",
@@ -82,8 +71,8 @@ module Godmin
           if collection.is_a? ActiveRecord::Relation
             @template.options_from_collection_for_select(
               collection,
-              :to_s,
-              :id,
+              filter.option_value,
+              filter.option_text,
               selected: default_filter_value(filter.identifier)
             )
           else

--- a/lib/godmin/resources/resource_service.rb
+++ b/lib/godmin/resources/resource_service.rb
@@ -6,6 +6,8 @@ require "godmin/resources/resource_service/pagination"
 require "godmin/resources/resource_service/scopes"
 require "godmin/filter/base"
 require "godmin/filter/string"
+require "godmin/filter/select"
+require "godmin/filter/multi_select"
 require "godmin/filter/boolean"
 
 module Godmin

--- a/lib/godmin/resources/resource_service.rb
+++ b/lib/godmin/resources/resource_service.rb
@@ -4,6 +4,9 @@ require "godmin/resources/resource_service/filters"
 require "godmin/resources/resource_service/ordering"
 require "godmin/resources/resource_service/pagination"
 require "godmin/resources/resource_service/scopes"
+require "godmin/filter/base"
+require "godmin/filter/string"
+require "godmin/filter/boolean"
 
 module Godmin
   module Resources

--- a/lib/godmin/resources/resource_service/filters.rb
+++ b/lib/godmin/resources/resource_service/filters.rb
@@ -4,13 +4,11 @@ module Godmin
       module Filters
         extend ActiveSupport::Concern
 
-        delegate :filter_map, to: "self.class"
-
         def apply_filters(filter_params, resources)
           if filter_params.present?
             filter_params.each do |name, value|
-              filter = filter_for(name)
-              resources = filter.call(value, resources) if filter
+              filter = filters[name]
+              resources = filter.call(resources, value) if filter
             end
           end
           resources
@@ -20,21 +18,6 @@ module Godmin
           return {} unless defined? self.class::FILTERS
           @_filters ||= self.class::FILTERS.each_with_object({}) { |f, hash| hash[f.identifier.to_s] = f }
         end
-
-        private
-
-        def filter_for(field)
-          filters[field]
-        end
-
-        # def filter(attr, options = {})
-        #   filter_map[attr] = {
-        #     as: :string,
-        #     option_text: "to_s",
-        #     option_value: "id",
-        #     collection: nil
-        #   }.merge(options)
-        # end
       end
     end
   end

--- a/lib/godmin/resources/resource_service/filters.rb
+++ b/lib/godmin/resources/resource_service/filters.rb
@@ -9,35 +9,32 @@ module Godmin
         def apply_filters(filter_params, resources)
           if filter_params.present?
             filter_params.each do |name, value|
-              if apply_filter?(name, value)
-                resources = send("filter_#{name}", resources, value)
-              end
+              filter = filter_for(name)
+              resources = filter.call(value, resources) if filter
             end
           end
           resources
         end
 
+        def filters
+          return {} unless defined? self.class::FILTERS
+          @_filters ||= self.class::FILTERS.each_with_object({}) { |f, hash| hash[f.identifier.to_s] = f }
+        end
+
         private
 
-        def apply_filter?(name, value)
-          return false if value == [""]
-          filter_map.key?(name.to_sym) && value.present?
+        def filter_for(field)
+          filters[field]
         end
 
-        module ClassMethods
-          def filter_map
-            @filter_map ||= {}
-          end
-
-          def filter(attr, options = {})
-            filter_map[attr] = {
-              as: :string,
-              option_text: "to_s",
-              option_value: "id",
-              collection: nil
-            }.merge(options)
-          end
-        end
+        # def filter(attr, options = {})
+        #   filter_map[attr] = {
+        #     as: :string,
+        #     option_text: "to_s",
+        #     option_value: "id",
+        #     collection: nil
+        #   }.merge(options)
+        # end
       end
     end
   end

--- a/lib/godmin/resources/resource_service/filters.rb
+++ b/lib/godmin/resources/resource_service/filters.rb
@@ -8,7 +8,7 @@ module Godmin
           if filter_params.present?
             filter_params.each do |name, value|
               filter = filters[name]
-              resources = filter.call(resources, value) if filter
+              resources = filter.call(resources, value) if filter && value.present?
             end
           end
           resources


### PR DESCRIPTION
This is a PR where I will work on #218. I will first focus on the filters and maybe I'll do the actions, scopes and so on afterwards.

### New way of defining filters in services
Instead of using a meta programming as before we use constant `FILTERS`. It is just an array which lists all filters you want. The filters themselves are now separated from the service as individual objects. There are a few good things about this separation.

1. It allows filters to be shared between resources easily (even projects if you'd like).
2. Godmin can ship with some nice default filters which, hopefully, can cover most of the cases.
3. Easy to test

Example:
```ruby
module Admin
  class ArticleService
    include Godmin::Resources::ResourceService

    FILTERS = [
      Godmin::Filter::String.new(:my_identifier, column: :title, wildcard: :post),
      Godmin::Filter::Boolean.new(:published, collection: [["Published", 1], ["Unpublished", 0]])
    ]
  end
end
```

**Update**
Clarification of `Godmin::Filter::String.new(:my_identifier, column: :title, wildcard: :post)`
The first parameter to the filters is the identifier. This is used as the name of the filter, used when finding what filter to apply with what filter params etc. By default this value is also used as the name of the column to filter, so I could have done this:
`Godmin::Filter::String.new(:title, wildcard: :post)`
which would use `:title` as both the identifier _and_ column name.

### Creating custom filters
Creating custom filters would be quite easy. You only need to create a class and implement a `call` method that takes a value and a scope.

Example: (this filter doesn't make much sense but anyway 😸 )
```ruby
# Always filters out records with matching column and are cats.
module Filter
  class Cat < Godmin::Filter::Base
    def call(value, scope)
      scope.where(column => value).where(cat: true)
    end
  end
end

module Admin
  class ArticleService
    include Godmin::Resources::ResourceService

    FILTERS = [
      Filter::Cat.new(:title)
    ]
  end
end
```

### Views
Each filter defines a `to_partial_path` which makes it easy to render with rails built in render method.
This method renders a partial like `filters/_string.html.erb` by default (string is the name of the filter). So, the cat filter above would render`filters/_cat.html.erb`.

The views are simple, looking like this:

```ruby
<%
# Local variables:
#  `form` is the filter form object.
#  `filter` is the filter being rendered
%>

<%= form.string_filter_field(filter) %>
```

To the `*_filter_field` methods you can pass options as usual with rails.
See: https://github.com/varvet/godmin/blob/04abc4cb7a8f070a1115394e384e8ee049b09d18/lib/godmin/helpers/filters.rb


### To think about
#### What default filters do we want to ship with Godmin?

Let's start with:
  - String filter (with wildcard options)
  - Boolean filter (dropdown with true/false options. Customizable collection.)
  - Select filter
  - Multiselect filter

#### View overriding
Out of the box it's possible to override a filter partial by just putting your own partial in the appropriate place.
To override the string filter partial for instance:
Godmin location: `views/godmin/filters/_string.html.erb`
Your location: `views/admin/filters/_string.html.erb` ("admin" is your engine name if you have any)

However, this would override it for _all_ filters in your app. Perhaps you want to override for a specific resource. We have two options here, that I can think of.
1. Use our custom `override_partial`-thing as we do with other partials at the moment.
2. Make the user define their own filter for this.

Let's say I want a custom view for a my article string filter.

```ruby
module Admin
  module Filter
    class ArticleString < Godmin::Filter::String
    end
  end
end

# put view in: view/admin/filters/_article_string.html.erb
```

Or if you want the view somewhere else, override `to_partial_path`:

```ruby
module Admin
  module Filter
    class ArticleString < Godmin::Filter::String
      def to_partial_path
        "article/filters/string"
      end
    end
  end
end

# put view in: view/admin/articles/filters/_string.html.erb
```

Any thoughts here @jensljungblad ?