### PR TITLE
Fix partial_override helper method

### DIFF
--- a/lib/godmin/helpers/application.rb
+++ b/lib/godmin/helpers/application.rb
@@ -4,17 +4,17 @@ module Godmin
       # Renders the provided partial with locals if it exists, otherwise
       # yields the given block. The lookup context call is cached for
       # each partial.
-      def partial_override(partial, locals = {})
+      def partial_override(partial, locals = {}, &block)
         @_partial_override ||= {}
 
-        if @_partial_override[partial].nil?
+        unless @_partial_override.key?(partial)
           @_partial_override[partial] = lookup_context.exists?(partial, nil, true)
         end
 
         if @_partial_override[partial]
           render partial: partial, locals: locals
         else
-          yield
+          capture(&block)
         end
       end
 


### PR DESCRIPTION
This commit fixes an issue with duplicating yielded content if the method was invoked from a template handled by slim.
Also it prevents repeating of invoking the `lookup_context` method for unfound partials in performance reasons.