### PR TITLE
[WIP] Remove instance variables

### DIFF
--- a/app/views/godmin/resource/_batch_actions.html.erb
+++ b/app/views/godmin/resource/_batch_actions.html.erb
@@ -1,11 +1,11 @@
-<% if @resource_service.include_batch_actions? %>
+<% if resource_service.include_batch_actions? %>
   <%= link_to translate_scoped("batch_actions.buttons.select_all"), "#", class: "btn btn-default",
     data: { behavior: "batch-actions-select batch-actions-select-all" } %>
   <%= link_to translate_scoped("batch_actions.buttons.deselect_all"), "#", class: "btn btn-default hidden",
     data: { behavior: "batch-actions-select batch-actions-select-none" } %>
 
   <div class="btn-group">
-    <% @resource_service.batch_action_map.each do |name, options| %>
+    <% resource_service.batch_action_map.each do |name, options| %>
       <%= batch_action_link(name, options) %>
     <% end %>
   </div>

--- a/app/views/godmin/resource/_breadcrumb.html.erb
+++ b/app/views/godmin/resource/_breadcrumb.html.erb
@@ -1,7 +1,7 @@
 <div id="breadcrumb">
   <ol class="breadcrumb">
-    <% if @resource_parents %>
-      <% @resource_parents.each do |parent| %>
+    <% if resource_parents %>
+      <% resource_parents.each do |parent| %>
         <li>
           <%= link_to parent.class.model_name.human(count: 2), parent.class %>
         </li>
@@ -12,20 +12,20 @@
     <% end %>
     <% if action_name == "index" %>
       <li class="active">
-        <%= @resource_class.model_name.human(count: 2) %>
+        <%= resource_class.model_name.human(count: 2) %>
       </li>
     <% else %>
       <li>
-        <%= link_to @resource_class.model_name.human(count: 2), [*@resource_parents, @resource_class] %>
+        <%= link_to resource_class.model_name.human(count: 2), [*resource_parents, resource_class] %>
       </li>
       <li class="active">
-        <% if @resource.new_record? %>
-          <%= t("helpers.submit.create", model: @resource_class.model_name.human) %>
+        <% if resource.new_record? %>
+          <%= t("helpers.submit.create", model: resource_class.model_name.human) %>
         <% else %>
-          <%= @resource.to_s %>
+          <%= resource.to_s %>
         <% end %>
       </li>
-      <% if @resource.persisted? %>
+      <% if resource.persisted? %>
         <%= render partial: "breadcrumb_actions" %>
       <% end %>
     <% end %>

--- a/app/views/godmin/resource/_breadcrumb_actions.html.erb
+++ b/app/views/godmin/resource/_breadcrumb_actions.html.erb
@@ -3,36 +3,36 @@
     <%= translate_scoped("actions.label") %> <span class="caret"></span>
   </a>
   <ul class="dropdown-menu">
-    <% if policy(@resource).show? && action_name != "show" %>
+    <% if policy(resource).show? && action_name != "show" %>
       <li>
-        <%= link_to translate_scoped("actions.show"), [*@resource_parents, @resource] %>
+        <%= link_to translate_scoped("actions.show"), [*resource_parents, resource] %>
       </li>
     <% end %>
-    <% if policy(@resource).edit? && action_name != "edit" %>
+    <% if policy(resource).edit? && action_name != "edit" %>
       <li>
-        <%= link_to translate_scoped("actions.edit"), [:edit, *@resource_parents, @resource]  %>
+        <%= link_to translate_scoped("actions.edit"), [:edit, *resource_parents, resource]  %>
       </li>
     <% end %>
-    <% if policy(@resource).destroy? %>
+    <% if policy(resource).destroy? %>
       <li>
-        <%= link_to translate_scoped("actions.destroy"), [*@resource_parents, @resource], method: :delete,
+        <%= link_to translate_scoped("actions.destroy"), [*resource_parents, resource], method: :delete,
           data: { confirm: translate_scoped("actions.confirm_message") } %>
       </li>
     <% end %>
   </ul>
 </li>
 
-<% if @resource_service.has_many_map.present? %>
+<% if resource_service.has_many_map.present? %>
   <li class="dropdown pull-right">
     <a href="#" data-toggle="dropdown">
       <%= translate_scoped("associations.label") %> <span class="caret"></span>
     </a>
     <ul class="dropdown-menu">
-      <% @resource_service.has_many_map.each do |name, options| %>
+      <% resource_service.has_many_map.each do |name, options| %>
         <% if policy(options[:class_name].constantize).index? %>
           <li>
             <%= link_to(options[:class_name].constantize.model_name.human(count: 2),
-              send("#{@resource_class.name.underscore}_#{name}_path", @resource)) %>
+              send("#{resource_class.name.underscore}_#{name}_path", resource)) %>
           </li>
         <% end %>
       <% end %>

--- a/app/views/godmin/resource/_button_actions.html.erb
+++ b/app/views/godmin/resource/_button_actions.html.erb
@@ -1,3 +1,3 @@
-<% if policy(@resource_service.build_resource({})).new? %>
-  <%= link_to t("helpers.submit.create", model: @resource_class.model_name.human), [:new, *@resource_parents, @resource_class.model_name.singular_route_key], class: "btn btn-default" %>
+<% if policy(resource_service.build_resource({})).new? %>
+  <%= link_to t("helpers.submit.create", model: resource_class.model_name.human), [:new, *resource_parents, resource_class.model_name.singular_route_key], class: "btn btn-default" %>
 <% end %>

--- a/app/views/godmin/resource/_export_actions.html.erb
+++ b/app/views/godmin/resource/_export_actions.html.erb
@@ -1,4 +1,4 @@
-<% if @resource_service.attrs_for_export.present? %>
+<% if resource_service.attrs_for_export.present? %>
   <div class="btn-group">
     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
       <%= translate_scoped("actions.export") %> <span class="caret"></span>

--- a/app/views/godmin/resource/_filters.html.erb
+++ b/app/views/godmin/resource/_filters.html.erb
@@ -1,11 +1,11 @@
-<% if @resource_service.filter_map.present? %>
+<% if resource_service.filter_map.present? %>
   <div id="filters" class="panel panel-default">
     <div class="panel-body">
       <%= filter_form do |f| %>
         <%= f.hidden_field :scope, value: params[:scope] %>
         <%= f.hidden_field :order, value: params[:order] %>
 
-        <% @resource_service.filter_map.each do |name, options| %>
+        <% resource_service.filter_map.each do |name, options| %>
           <%= partial_override "#{controller_path}/filters/#{name}", f: f, name: name, options: options do %>
             <%= f.filter_field(name, options) %>
           <% end %>

--- a/app/views/godmin/resource/_form.html.erb
+++ b/app/views/godmin/resource/_form.html.erb
@@ -1,5 +1,5 @@
-<%= form_for @resource do |f| %>
-  <% @resource_service.attrs_for_form.each do |attribute| %>
+<%= form_for resource do |f| %>
+  <% resource_service.attrs_for_form.each do |attribute| %>
     <% if f.object.class.reflect_on_association(attribute) %>
       <%= f.association attribute %>
     <% else %>

--- a/app/views/godmin/resource/_pagination.html.erb
+++ b/app/views/godmin/resource/_pagination.html.erb
@@ -1,40 +1,40 @@
 <div class="pull-left">
-  <% if @resource_service.paginator.total_pages > 1 %>
+  <% if resource_service.paginator.total_pages > 1 %>
     <nav>
       <ul class="pagination">
-        <% unless @resource_service.paginator.pages.first == 1 && @resource_service.paginator.current_page == @resource_service.paginator.pages.first %>
+        <% unless resource_service.paginator.pages.first == 1 && resource_service.paginator.current_page == resource_service.paginator.pages.first %>
           <li><%= link_to translate_scoped("pagination.first"), params.to_unsafe_h.merge(page: 1) %></li>
-          <li><%= link_to "«", params.to_unsafe_h.merge(page: @resource_service.paginator.current_page - 1) %></li>
+          <li><%= link_to "«", params.to_unsafe_h.merge(page: resource_service.paginator.current_page - 1) %></li>
         <% end %>
-        <% unless @resource_service.paginator.pages.first == 1 %>
+        <% unless resource_service.paginator.pages.first == 1 %>
           <li class="disabled"><%= link_to "…" %></li>
         <% end %>
-        <% @resource_service.paginator.pages.each do |page| %>
-          <li class="<%= "active" if page == @resource_service.paginator.current_page %>">
+        <% resource_service.paginator.pages.each do |page| %>
+          <li class="<%= "active" if page == resource_service.paginator.current_page %>">
             <%= link_to page, params.to_unsafe_h.merge(page: page) %>
           </li>
         <% end %>
-        <% unless @resource_service.paginator.pages.last == @resource_service.paginator.total_pages %>
+        <% unless resource_service.paginator.pages.last == resource_service.paginator.total_pages %>
           <li class="disabled"><%= link_to "…" %></li>
         <% end %>
-        <% unless @resource_service.paginator.pages.last == @resource_service.paginator.total_pages && @resource_service.paginator.current_page == @resource_service.paginator.pages.last %>
-          <li><%= link_to "»", params.to_unsafe_h.merge(page: @resource_service.paginator.current_page + 1) %></li>
-          <li><%= link_to translate_scoped("pagination.last"), params.to_unsafe_h.merge(page: @resource_service.paginator.total_pages) %></li>
+        <% unless resource_service.paginator.pages.last == resource_service.paginator.total_pages && resource_service.paginator.current_page == resource_service.paginator.pages.last %>
+          <li><%= link_to "»", params.to_unsafe_h.merge(page: resource_service.paginator.current_page + 1) %></li>
+          <li><%= link_to translate_scoped("pagination.last"), params.to_unsafe_h.merge(page: resource_service.paginator.total_pages) %></li>
         <% end %>
       </ul>
     </nav>
   <% end %>
 </div>
 <div class="pagination-entries pull-right hidden-xs">
-  <% if @resources.length == 0 %>
+  <% if resources.length == 0 %>
     <%= translate_scoped("pagination.entries.zero", {
-      resource: @resource_class.model_name.human(count: @resources.length).downcase
+      resource: resource_class.model_name.human(count: resources.length).downcase
     }) %>
   <% else %>
     <%= translate_scoped("pagination.entries.other", {
-      resource: @resource_class.model_name.human(count: @resources.length).downcase,
-      count: @resources.length,
-      total: @resource_service.paginator.total_resources
+      resource: resource_class.model_name.human(count: resources.length).downcase,
+      count: resources.length,
+      total: resource_service.paginator.total_resources
     }) %>
   <% end %>
 </div>

--- a/app/views/godmin/resource/_scopes.html.erb
+++ b/app/views/godmin/resource/_scopes.html.erb
@@ -1,11 +1,11 @@
-<% unless @resource_service.scope_map.empty? %>
+<% unless resource_service.scope_map.empty? %>
   <div id="scopes">
     <ul class="nav nav-tabs">
-      <% @resource_service.scope_map.each do |name, options| %>
-        <li class="<%= "active" if @resource_service.scoped_by?(name) %>">
+      <% resource_service.scope_map.each do |name, options| %>
+        <li class="<%= "active" if resource_service.scoped_by?(name) %>">
           <%= link_to url_for(params.to_unsafe_h.merge(scope: name, only_path: true).except(:page)) do %>
             <%= translate_scoped("scopes.labels.#{name.to_s.underscore}", default: name.to_s.titleize) %>
-            <span class="text-muted"> (<%= @resource_service.scope_count(name) %>)</span>
+            <span class="text-muted"> (<%= resource_service.scope_count(name) %>)</span>
           <% end %>
         </li>
       <% end %>

--- a/app/views/godmin/resource/_table.html.erb
+++ b/app/views/godmin/resource/_table.html.erb
@@ -1,14 +1,14 @@
 <div id="table" class="table-responsive">
   <table class="table table-bordered table-hover">
     <caption class="hide">
-      <%= @resource_class.model_name.human(count: 2) %>
+      <%= resource_class.model_name.human(count: 2) %>
     </caption>
     <thead>
       <tr>
-        <% if @resource_service.include_batch_actions? %>
+        <% if resource_service.include_batch_actions? %>
           <th></th>
         <% end %>
-        <% @resource_service.attrs_for_index.each do |attr| %>
+        <% resource_service.attrs_for_index.each do |attr| %>
           <th class="column-<%= attr %>">
             <%= column_header attr %>
           </th>
@@ -17,15 +17,15 @@
       </tr>
     </thead>
     <tbody>
-      <% @resources.each do |resource| %>
+      <% resources.each do |resource| %>
         <tr data-resource-id="<%= resource.id %>" class="<%= "highlight" if flash[:updated_ids] && flash[:updated_ids].include?(resource.id) %>">
-          <% if @resource_service.include_batch_actions? %>
+          <% if resource_service.include_batch_actions? %>
             <td align="center" data-behavior="batch-actions-checkbox-container">
               <%= check_box_tag "batch_action[items][#{resource.id}]", nil, nil,
                 data: { behavior: "batch-actions-checkbox" } %>
             </td>
           <% end %>
-          <% @resource_service.attrs_for_index.each do |attr| %>
+          <% resource_service.attrs_for_index.each do |attr| %>
             <td>
               <%= column_value(resource, attr) %>
             </td>

--- a/app/views/godmin/resource/columns/_actions.html.erb
+++ b/app/views/godmin/resource/columns/_actions.html.erb
@@ -2,7 +2,7 @@
   <% if policy(resource).show? %>
     <%= link_to(
       translate_scoped("actions.show"),
-      [*@resource_parents, resource],
+      [*resource_parents, resource],
       class: "btn btn-default",
       title: translate_scoped("actions.show_title", resource: resource)
     ) %>
@@ -10,7 +10,7 @@
   <% if policy(resource).edit? %>
     <%= link_to(
       translate_scoped("actions.edit"),
-      [:edit, *@resource_parents, resource],
+      [:edit, *resource_parents, resource],
       class: "btn btn-default",
       title: translate_scoped("actions.edit_title", resource: resource)
     ) %>
@@ -18,7 +18,7 @@
   <% if policy(resource).destroy? %>
     <%= link_to(
       translate_scoped("actions.destroy"),
-      [*@resource_parents, resource],
+      [*resource_parents, resource],
       method: :delete,
       class: "btn btn-default",
       title: translate_scoped("actions.destroy_title", resource: resource),

--- a/app/views/godmin/resource/edit.html.erb
+++ b/app/views/godmin/resource/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "breadcrumb" %>
 
-<%= render partial: "errors", locals: { errors: @resource.errors } %>
+<%= render partial: "errors", locals: { errors: resource.errors } %>
 
 <%= render partial: "form" %>

--- a/app/views/godmin/resource/index.csv.csvbuilder
+++ b/app/views/godmin/resource/index.csv.csvbuilder
@@ -1,5 +1,5 @@
-csv << @resource_service.attrs_for_export
+csv << resource_service.attrs_for_export
 
-@resources.limit(nil).offset(nil).each do |resource|
-  csv << @resource_service.attrs_for_export.map { |attr| resource.send(attr) }
+resources.limit(nil).offset(nil).each do |resource|
+  csv << resource_service.attrs_for_export.map { |attr| resource.send(attr) }
 end

--- a/app/views/godmin/resource/index.html.erb
+++ b/app/views/godmin/resource/index.html.erb
@@ -1,10 +1,10 @@
-<%= render partial: "breadcrumb" %>
-<%= render partial: "scopes" %>
-<%= render partial: "filters" %>
+<%= render "breadcrumb", resource_class: resource_class, resource_parents: resource_parents %>
+<%= render "scopes", resource_service: resource_service %>
+<%= render "filters", resource_service: resource_service, resource_parents: resource_parents %>
 
 <div data-behavior="batch-actions-container">
-  <%= render partial: "actions" %>
-  <%= render partial: "table" %>
+  <%= render "actions" %>
+  <%= render "table" %>
 </div>
 
-<%= render partial: "pagination" %>
+<%= render "pagination" %>

--- a/app/views/godmin/resource/index.json.jbuilder
+++ b/app/views/godmin/resource/index.json.jbuilder
@@ -1,3 +1,3 @@
-json.array! @resources.limit(nil).offset(nil) do |resource|
-  json.extract! resource, *@resource_service.attrs_for_export
+json.array! resources.limit(nil).offset(nil) do |resource|
+  json.extract! resource, *resource_service.attrs_for_export
 end

--- a/app/views/godmin/resource/new.html.erb
+++ b/app/views/godmin/resource/new.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "breadcrumb" %>
 
-<%= render partial: "errors", locals: { errors: @resource.errors } %>
+<%= render partial: "errors", locals: { errors: resource.errors } %>
 
 <%= render partial: "form" %>

--- a/app/views/godmin/resource/show.html.erb
+++ b/app/views/godmin/resource/show.html.erb
@@ -1,10 +1,10 @@
 <%= render partial: "breadcrumb" %>
 
 <table class="table">
-  <% @resource_service.attrs_for_show.each do |attr| %>
+  <% resource_service.attrs_for_show.each do |attr| %>
     <tr>
-      <th><%= @resource_class.human_attribute_name(attr) %></th>
-      <td><%= column_value(@resource, attr) %></td>
+      <th><%= resource_class.human_attribute_name(attr) %></th>
+      <td><%= column_value(resource, attr) %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/godmin/resource/show.json.jbuilder
+++ b/app/views/godmin/resource/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @resource, *@resource_service.attrs_for_export
+json.extract! resource, *resource_service.attrs_for_export

--- a/lib/godmin/helpers/batch_actions.rb
+++ b/lib/godmin/helpers/batch_actions.rb
@@ -2,11 +2,11 @@ module Godmin
   module Helpers
     module BatchActions
       def batch_action_link(name, options)
-        return unless @resource_service.include_batch_action?(name)
+        return unless resource_service.include_batch_action?(name)
 
         link_to(
           translate_scoped("batch_actions.labels.#{name}", default: name.to_s.titleize),
-          [*@resource_parents, @resource_class],
+          [*resource_parents, resource_class],
           method: :patch,
           class: "btn btn-default hidden",
           data: {

--- a/lib/godmin/helpers/forms.rb
+++ b/lib/godmin/helpers/forms.rb
@@ -3,7 +3,7 @@ module Godmin
     module Forms
       def form_for(record, options = {}, &block)
         super(record, {
-          url: [*@resource_parents, record],
+          url: [*resource_parents, record],
           builder: FormBuilders::FormBuilder,
           inline_errors: false
         }.merge(options), &block)

--- a/lib/godmin/helpers/tables.rb
+++ b/lib/godmin/helpers/tables.rb
@@ -2,7 +2,7 @@ module Godmin
   module Helpers
     module Tables
       def column_header(attribute)
-        if @resource_service.orderable_column?(attribute.to_s)
+        if resource_service.orderable_column?(attribute.to_s)
           direction =
             if params[:order].present?
               if params[:order].match(/\A#{attribute.to_s}_(asc|desc)\z/)
@@ -15,9 +15,9 @@ module Godmin
             else
               "desc"
             end
-          link_to @resource_class.human_attribute_name(attribute.to_s), url_for(params.to_unsafe_h.merge(order: "#{attribute}_#{direction}"))
+          link_to resource_class.human_attribute_name(attribute.to_s), url_for(params.to_unsafe_h.merge(order: "#{attribute}_#{direction}"))
         else
-          @resource_class.human_attribute_name(attribute.to_s)
+          resource_class.human_attribute_name(attribute.to_s)
         end
       end
 

--- a/lib/godmin/helpers/translations.rb
+++ b/lib/godmin/helpers/translations.rb
@@ -2,17 +2,17 @@ module Godmin
   module Helpers
     module Translations
       def translate_scoped(translate, scope: nil, default: nil, **options)
-        if resource_class
-          scope ||= resource_class.to_s.underscore
-        end
-
-        defaults = [
-          ["godmin", scope, translate].compact.join(".").to_sym,
-          ["godmin", translate].compact.join(".").to_sym,
-          default
-        ]
-
-        t(defaults.shift, default: defaults, **options)
+        # if resource_class
+        #   scope ||= resource_class.to_s.underscore
+        # end
+        #
+        # defaults = [
+        #   ["godmin", scope, translate].compact.join(".").to_sym,
+        #   ["godmin", translate].compact.join(".").to_sym,
+        #   default
+        # ]
+        #
+        # t(defaults.shift, default: defaults, **options)
       end
     end
   end

--- a/lib/godmin/helpers/translations.rb
+++ b/lib/godmin/helpers/translations.rb
@@ -2,8 +2,8 @@ module Godmin
   module Helpers
     module Translations
       def translate_scoped(translate, scope: nil, default: nil, **options)
-        if @resource_class
-          scope ||= @resource_class.to_s.underscore
+        if resource_class
+          scope ||= resource_class.to_s.underscore
         end
 
         defaults = [

--- a/lib/godmin/resources/resource_controller.rb
+++ b/lib/godmin/resources/resource_controller.rb
@@ -22,11 +22,11 @@ module Godmin
 
         # TODO: helper methods are available everywhere to all partials, try using
         # locals instead so we only pass the stuff we need...
-        helper_method :resource_class
-        helper_method :resource_service
-        helper_method :resource_parents
-        helper_method :resources
-        helper_method :resource
+        # helper_method :resource_class
+        # helper_method :resource_service
+        # helper_method :resource_parents
+        # helper_method :resources
+        # helper_method :resource
       end
 
       def index
@@ -34,8 +34,15 @@ module Godmin
         resource_service
         resources
 
+        locals = {
+          resource_class: resource_class,
+          resource_service: resource_service,
+          resource_parents: resource_parents,
+          resources: resources
+        }
+
         respond_to do |format|
-          format.html
+          format.html { render :index, locals: locals }
           format.json
           format.csv
         end

--- a/lib/godmin/resources/resource_controller.rb
+++ b/lib/godmin/resources/resource_controller.rb
@@ -3,6 +3,11 @@ require "godmin/helpers/filters"
 require "godmin/helpers/tables"
 require "godmin/resources/resource_controller/batch_actions"
 
+# problem: we are modifying the resource service during the request cycle, which means
+# we need to memoize all calls to service, resource etc. not good...
+# we should build up things in the controller, not from the view layer?
+# https://github.com/thoughtbot/guides/pull/398
+
 module Godmin
   module Resources
     module ResourceController
@@ -15,20 +20,20 @@ module Godmin
         helper Godmin::Helpers::Filters
         helper Godmin::Helpers::Tables
 
+        # TODO: helper methods are available everywhere to all partials, try using
+        # locals instead so we only pass the stuff we need...
         helper_method :resource_class
         helper_method :resource_service
         helper_method :resource_parents
         helper_method :resources
         helper_method :resource
-
-        # before_action :set_resource_service
-        # before_action :set_resource_class
-        # before_action :set_resource_parents
-        # before_action :set_resources, only: :index
-        # before_action :set_resource, only: [:show, :new, :edit, :create, :update, :destroy]
       end
 
       def index
+        # TODO: needed because things need to happen in a certain order, not good
+        resource_service
+        resources
+
         respond_to do |format|
           format.html
           format.json
@@ -48,31 +53,35 @@ module Godmin
       def edit; end
 
       def create
+        # TODO: needed because things need to happen in a certain order, not good
+        resource_service
+        resource
+
         respond_to do |format|
-          if @resource_service.create_resource(@resource)
+          if resource_service.create_resource(resource)
             format.html { redirect_to redirect_after_create, notice: redirect_flash_message }
-            format.json { render :show, status: :created, location: @resource }
+            format.json { render :show, status: :created, location: resource }
           else
             format.html { render :edit }
-            format.json { render json: @resource.errors, status: :unprocessable_entity }
+            format.json { render json: resource.errors, status: :unprocessable_entity }
           end
         end
       end
 
       def update
         respond_to do |format|
-          if @resource_service.update_resource(@resource, resource_params)
+          if resource_service.update_resource(resource, resource_params)
             format.html { redirect_to redirect_after_update, notice: redirect_flash_message }
-            format.json { render :show, status: :ok, location: @resource }
+            format.json { render :show, status: :ok, location: resource }
           else
             format.html { render :edit }
-            format.json { render json: @resource.errors, status: :unprocessable_entity }
+            format.json { render json: resource.errors, status: :unprocessable_entity }
           end
         end
       end
 
       def destroy
-        @resource_service.destroy_resource(@resource)
+        resource_service.destroy_resource(resource)
 
         respond_to do |format|
           format.html { redirect_to redirect_after_destroy, notice: redirect_flash_message }
@@ -82,72 +91,63 @@ module Godmin
 
       protected
 
-      # def set_resource_service
-      #   @resource_service = resource_service
-      # end
-      #
-      # def set_resource_class
-      #   @resource_class = resource_class
-      # end
-      #
-      # def set_resource_parents
-      #   @resource_parents = resource_parents
-      # end
-      #
-      # def set_resources
-      #   @resources = resources
-      #   authorize(@resources) if authorization_enabled? # TODO: MOVE!
-      # end
-      #
-      # def set_resource
-      #   @resource = resource
-      #   authorize(@resource) if authorization_enabled? # TODO: MOVE!
-      # end
-
       def resource_service_class
-        "#{controller_path.singularize}_service".classify.constantize
+        @_resource_service_class ||= "#{controller_path.singularize}_service".classify.constantize
       end
 
       def resource_service
-        resource_service = resource_service_class.new
+        @_resource_service ||= begin
+          resource_service = resource_service_class.new
 
-        if authentication_enabled?
-          resource_service.options[:admin_user] = admin_user
+          if authentication_enabled?
+            resource_service.options[:admin_user] = admin_user
+          end
+
+          if resource_parents.present?
+            resource_service.options[:resource_parent] = resource_parents.last
+          end
+
+          resource_service
         end
-
-        if resource_parents.present?
-          resource_service.options[:resource_parent] = resource_parents.last
-        end
-
-        resource_service
       end
 
       def resource_class
-        resource_service.resource_class
+        @_resource_class ||= resource_service.resource_class
       end
 
       def resource_parents
-        params.to_unsafe_h.each_with_object([]) do |(name, value), parents|
-          if name =~ /(.+)_id$/
-            parents << $1.classify.constantize.find(value)
+        @_resource_parents ||= begin
+          params.to_unsafe_h.each_with_object([]) do |(name, value), parents|
+            if name =~ /(.+)_id$/
+              parents << $1.classify.constantize.find(value)
+            end
           end
         end
       end
 
       def resources
-        resource_service.resources(params)
+        @_resources ||= begin
+          resources = resource_service.resources(params)
+          authorize(resources) if authorization_enabled?
+          resources
+        end
       end
 
       def resource
-        if params[:id]
-          resource_service.find_resource(params[:id])
-        else
-          case action_name
-          when "create"
-            resource_service.build_resource(resource_params)
-          when "new"
-            resource_service.build_resource(nil)
-          end
+        @_resource ||= begin
+          resource =
+            if params[:id]
+              resource_service.find_resource(params[:id])
+            else
+              case action_name
+              when "create"
+                resource_service.build_resource(resource_params)
+              when "new"
+                resource_service.build_resource(nil)
+              end
+            end
+          authorize(resource) if authorization_enabled?
+          resource
         end
       end
 

--- a/lib/godmin/resources/resource_controller.rb
+++ b/lib/godmin/resources/resource_controller.rb
@@ -15,11 +15,17 @@ module Godmin
         helper Godmin::Helpers::Filters
         helper Godmin::Helpers::Tables
 
-        before_action :set_resource_service
-        before_action :set_resource_class
-        before_action :set_resource_parents
-        before_action :set_resources, only: :index
-        before_action :set_resource, only: [:show, :new, :edit, :create, :update, :destroy]
+        helper_method :resource_class
+        helper_method :resource_service
+        helper_method :resource_parents
+        helper_method :resources
+        helper_method :resource
+
+        # before_action :set_resource_service
+        # before_action :set_resource_class
+        # before_action :set_resource_parents
+        # before_action :set_resources, only: :index
+        # before_action :set_resource, only: [:show, :new, :edit, :create, :update, :destroy]
       end
 
       def index
@@ -76,27 +82,27 @@ module Godmin
 
       protected
 
-      def set_resource_service
-        @resource_service = resource_service
-      end
-
-      def set_resource_class
-        @resource_class = resource_class
-      end
-
-      def set_resource_parents
-        @resource_parents = resource_parents
-      end
-
-      def set_resources
-        @resources = resources
-        authorize(@resources) if authorization_enabled?
-      end
-
-      def set_resource
-        @resource = resource
-        authorize(@resource) if authorization_enabled?
-      end
+      # def set_resource_service
+      #   @resource_service = resource_service
+      # end
+      #
+      # def set_resource_class
+      #   @resource_class = resource_class
+      # end
+      #
+      # def set_resource_parents
+      #   @resource_parents = resource_parents
+      # end
+      #
+      # def set_resources
+      #   @resources = resources
+      #   authorize(@resources) if authorization_enabled? # TODO: MOVE!
+      # end
+      #
+      # def set_resource
+      #   @resource = resource
+      #   authorize(@resource) if authorization_enabled? # TODO: MOVE!
+      # end
 
       def resource_service_class
         "#{controller_path.singularize}_service".classify.constantize
@@ -117,7 +123,7 @@ module Godmin
       end
 
       def resource_class
-        @resource_service.resource_class
+        resource_service.resource_class
       end
 
       def resource_parents
@@ -129,29 +135,29 @@ module Godmin
       end
 
       def resources
-        @resource_service.resources(params)
+        resource_service.resources(params)
       end
 
       def resource
         if params[:id]
-          @resource_service.find_resource(params[:id])
+          resource_service.find_resource(params[:id])
         else
           case action_name
           when "create"
-            @resource_service.build_resource(resource_params)
+            resource_service.build_resource(resource_params)
           when "new"
-            @resource_service.build_resource(nil)
+            resource_service.build_resource(nil)
           end
         end
       end
 
       def resource_params
-        params.require(@resource_class.model_name.param_key.to_sym).permit(resource_params_defaults)
+        params.require(resource_class.model_name.param_key.to_sym).permit(resource_params_defaults)
       end
 
       def resource_params_defaults
-        @resource_service.attrs_for_form.map do |attribute|
-          association = @resource_class.reflect_on_association(attribute)
+        resource_service.attrs_for_form.map do |attribute|
+          association = resource_class.reflect_on_association(attribute)
 
           if association && association.macro == :belongs_to
             association.foreign_key.to_sym
@@ -170,15 +176,15 @@ module Godmin
       end
 
       def redirect_after_save
-        [*@resource_parents, @resource]
+        [*resource_parents, resource]
       end
 
       def redirect_after_destroy
-        [*@resource_parents, resource_class.model_name.route_key.to_sym]
+        [*resource_parents, resource_class.model_name.route_key.to_sym]
       end
 
       def redirect_flash_message
-        translate_scoped("flash.#{action_name}", resource: @resource.class.model_name.human)
+        translate_scoped("flash.#{action_name}", resource: resource.class.model_name.human)
       end
     end
   end

--- a/lib/godmin/resources/resource_controller/batch_actions.rb
+++ b/lib/godmin/resources/resource_controller/batch_actions.rb
@@ -13,17 +13,14 @@ module Godmin
         def perform_batch_action
           return unless params[:batch_action].present?
 
-          set_resource_service
-          set_resource_class
-
           if authorization_enabled?
             authorize(batch_action_records, "batch_action_#{params[:batch_action]}?")
           end
 
-          if @resource_service.batch_action(params[:batch_action], batch_action_records)
+          if resource_service.batch_action(params[:batch_action], batch_action_records)
             flash[:notice] = translate_scoped(
               "flash.batch_action", number_of_records: batch_action_ids.length,
-                                    resource: @resource_class.model_name.human(count: batch_action_ids.length)
+                                    resource: resource_class.model_name.human(count: batch_action_ids.length)
             )
             flash[:updated_ids] = batch_action_ids
 
@@ -41,7 +38,7 @@ module Godmin
         end
 
         def batch_action_records
-          @_batch_action_records ||= @resource_class.where(id: batch_action_ids)
+          @_batch_action_records ||= resource_class.where(id: batch_action_ids)
         end
       end
     end


### PR DESCRIPTION
This PR attempts to solve #220.

Started looking at this and it will be tricky, but I like the concept. First I replaced all instance variables with helper methods, which I got working. Unfortunately our code is a bit hard to follow. The service object is modified during the request cycle by different parts of the code, so things need to happen in a particular order for things to work, which is why we set the instance variables in the order that we do. Not nice, we should try and fix that as well.

Then I tried replacing the helper methods with locals, which is what we want. That way, variables aren't automatically available to all views and partials, but have to be explicitly passed, which is nice. However, we have a problem with some of our view helpers, such as the translation and form helpers. They require access to `resource_class` and `resource_parents`. We could pass them to the translation helper, but it's trickier with the form helper which mimics the Rails helper.

Do we want to expose some things as helper methods, available everywhere and some things passed down as locals?

