### PR TITLE
Add appraisal for Rails 6 and fix failing Resolver

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,7 @@
 appraise "rails-5" do
   gem "rails", "~> 5.0"
 end
+
+appraise "rails-6" do
+  gem "rails", "~> 6.0"
+end

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "admin", path: "../test/dummy/admin", group: [:test, :development]
-gem "rails", "~> 5.0"
+gem "rails", "~> 6.0"
 
 gemspec path: "../"

--- a/godmin.gemspec
+++ b/godmin.gemspec
@@ -20,21 +20,24 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "bcrypt", [">= 3.0", "< 4.0"]
-  gem.add_dependency "bootstrap_form", "~> 2.4"
   gem.add_dependency "bootstrap-sass", "~> 3.3"
+  gem.add_dependency "bootstrap_form", "~> 2.4"
   gem.add_dependency "csv_builder", "~> 2.1"
   gem.add_dependency "jquery-rails", [">= 4.0", "< 5.0"]
   gem.add_dependency "momentjs-rails", "~> 2.8"
   gem.add_dependency "pundit", [">= 1.1", "< 2.0"]
-  gem.add_dependency "rails", [">= 5.0", "< 6.0"]
+  gem.add_dependency "rails", [">= 5.0", "< 7.0"]
   gem.add_dependency "sass-rails", [">= 5.0", "< 6.0"]
   gem.add_dependency "selectize-rails", "~> 0.12"
 
   gem.add_development_dependency "appraisal"
+  gem.add_development_dependency "bootsnap"
+  gem.add_development_dependency "byebug"
   gem.add_development_dependency "capybara"
-  gem.add_development_dependency "minitest-reporters"
   gem.add_development_dependency "minitest"
+  gem.add_development_dependency "minitest-reporters"
   gem.add_development_dependency "poltergeist"
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "puma"
   gem.add_development_dependency "sqlite3"
 end

--- a/lib/godmin/resolver.rb
+++ b/lib/godmin/resolver.rb
@@ -16,6 +16,9 @@ module Godmin
       @engine_wrapper = engine_wrapper
     end
 
+    # This function is for Rails 6 and up since the `find_templates` function
+    # is deprecated. It does the same thing, just a little differently. It's
+    # not being run by versions previous to Rails 6.
     def _find_all(name, prefix, partial, details, key, locals)
       templates = []
 
@@ -29,15 +32,14 @@ module Godmin
       templates
     end
 
+    # This is how we find templates in Rails 5 and below.
     def find_templates(name, prefix, *args)
       templates = []
 
       template_paths(prefix).each do |path|
-        if templates.present?
-          break
-        else
-          templates = super(name, path, *args)
-        end
+        break if templates.present?
+
+        templates = super(name, path, *args)
       end
 
       templates

--- a/lib/godmin/resolver.rb
+++ b/lib/godmin/resolver.rb
@@ -16,6 +16,19 @@ module Godmin
       @engine_wrapper = engine_wrapper
     end
 
+    def _find_all(name, prefix, partial, details, key, locals)
+      templates = []
+
+      template_paths(prefix).each do |p|
+        break if templates.present?
+
+        path = Path.build(name, "#{@path}/#{p}", partial)
+        templates = query(path, details, details[:formats], locals, cache: !!key)
+      end
+
+      templates
+    end
+
     def find_templates(name, prefix, *args)
       templates = []
 


### PR DESCRIPTION
We've been bitten by a change to `ActionView::FileSystemResolver`. I think it's this one https://github.com/rails/rails/commit/cc9a0de6602f3c33e5ffa168c75f90451b47a208 but it doesn't really matter. What it boils down to is the Rails 6 FileSystemResolver no longer uses `find_templates`. That means we have to find some other way of looking for our templates.

My solution is to hook into the `_find_all` function and do basically the same thing as before. It's a private method so we're treading on thin ice again, but it has the advantage of not being run by the pre-Rails 6 code which means we can just add that function and leave well enough alone.