### PR TITLE
Fix `module_parents` deprecation warning

### DIFF
--- a/lib/godmin/engine_wrapper.rb
+++ b/lib/godmin/engine_wrapper.rb
@@ -40,8 +40,17 @@ module Godmin
       end
     end
 
+    # Some gymnastics because the `parents` function is slated for deprecation
+    # and being replaced by `module_parents` and we don't want to clutter our
+    # log with a million warnings
+    def parents_of(controller)
+      return controller.module_parents if controller.respond_to?(:module_parents)
+
+      controller.parents
+    end
+
     def find_engine_module(controller)
-      controller.parents.find do |parent|
+      parents_of(controller).find do |parent|
         parent.respond_to?(:use_relative_model_naming?) && parent.use_relative_model_naming?
       end
     end


### PR DESCRIPTION
Builds are failing because of a Capybara issue. This will be fixed in #248 where we add puma as a dependency.