### PR TITLE
Patch incompatible code with newest Rails release

### DIFF
--- a/app/views/godmin/resource/_button_actions.html.erb
+++ b/app/views/godmin/resource/_button_actions.html.erb
@@ -1,3 +1,3 @@
 <% if policy(@resource_service.build_resource({})).new? %>
-  <%= link_to t("helpers.submit.create", model: @resource_class.model_name.human), [:new, *@resource_parents, @resource_class.model_name.singular_route_key], class: "btn btn-default" %>
+  <%= link_to t("helpers.submit.create", model: @resource_class.model_name.human), [:new, *@resource_parents, @resource_class.model_name.singular_route_key.to_sym], class: "btn btn-default" %>
 <% end %>


### PR DESCRIPTION
The latest Rails Security patch requires that polymorphic paths be constructed with symbols, rather than keys https://github.com/rails/rails/issues/42157

Release info: 
https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/