### PR TITLE
Build against more recent Rubies

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,8 +6,6 @@ engines:
     enabled: true
   csslint:
     enabled: true
-  bundler-audit:
-    enabled: true
 ratings:
   paths:
   - "**.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,14 @@
 bundler_args: --without debug
 cache: bundler
 script: "bundle exec rake test"
-sudo: false
 
 rvm:
-  - 2.2.2
-  - 2.3.5
-  - 2.5.1
+  - 2.6.7
+  - 2.7.3
 
 gemfile:
   - gemfiles/rails_5.gemfile
   - gemfiles/rails_6.gemfile
-
-matrix:
-  exclude:
-    - rvm: 2.2.2
-      gemfile: gemfiles/rails_6.gemfile
-    - rvm: 2.3.5
-      gemfile: gemfiles/rails_6.gemfile
 
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
-bundler_args: --without debug
+bundler_args: "--without debug"
 cache: bundler
-script: "bundle exec rake test"
-
+script: bundle exec rake test
 rvm:
   - 2.6.7
   - 2.7.3
-
 gemfile:
   - gemfiles/rails_5.gemfile
   - gemfiles/rails_6.gemfile
-
 addons:
   code_climate:
-    repo_token: 7e7ee66c976bdfe7a0d40d41958b97a1cf8a03b0462df5cba415f624c07c2071
+    repo_token:
+      secure: WBszVdtEvWM2KugFre9BpwkCduY6hjrmK7xo1GLiru4NMqr4ZoRXruQ5ijhZE79YqduR6zudKr72g9yG4R+4CK7ghYu4x5JB76IW8gFWpI9teTWrF4hdSbJgwxSH5JNkqWF4f6ic4Xr1Vgc43agzt+1KmA9imoGs2Q0EbAY3H2M=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### Next Release
+
+Bug fixes
+- Use symbol in path for compatibility with the latest Rails security patches (https://github.com/varvet/godmin/pull/256)
+
+Other
+- Build and test against Ruby 2.6 and 2.7
+- Stop building and testing against unsupported rubies (2.5 and older). These may still work and PRs may still be accepted.
+
 ### 2.0.0 - 2019-12-06
 
 Features

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "admin", path: "../test/dummy/admin", group: [:test, :development]
-gem "rails", "~> 5.0"
+gem "rails", "~> 5.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "admin", path: "../test/dummy/admin", group: [:test, :development]
-gem "rails", "~> 6.0"
+gem "rails", "~> 6.1"
 
 gemspec path: "../"


### PR DESCRIPTION
Ruby 2.5 became unsupported (end of life) on 2021-03-31:

  https://www.ruby-lang.org/en/downloads/branches/

Ruby 3 requires more of an update to handle the new way that keyword
arguments are managed. Let's deal with that in a later version.

Also make CodeClimate work.