### PR TITLE
Only look for pundit policies in the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Next release
+
+Bug fixes
+- Regression: within an Engine, always look for Pundit policies in the engine (https://github.com/varvet/godmin/pull/259)
+
 ### 2.1.0 - 2021-05-10
 
 Bug fixes

--- a/README.md
+++ b/README.md
@@ -874,6 +874,51 @@ class ArticlesController < ApplicationController
 end
 ```
 
+### Authorization in Engines
+
+When Godmin is installed as an engine, it expects policies to be defined
+within the engine: eg. `Admin::ArticlePolicy` defined in
+`admin/app/policies/article_policy.rb`.
+
+If your admin application is itself broken up into several engines, then
+either
+
+1. the policies for those engines need to live in the main engine, or
+2. those engines need to be namespaced under the namespace of the main engine.
+
+Here is one example of a directory structure for approach 2:
+
+```
+admin
+  ├── app
+  │   └── policies
+  │       └── admin
+  │           └── article_policy.rb
+  └── engines
+      └── content
+          └── policies
+              └── admin
+                  └── content
+                      └── text_block_policy.rb
+app
+  └── models
+      └── article.rb
+engines
+  └── content
+        └── models
+            └── content
+                └── text_block.rb
+```
+```ruby
+# admin/engines/content/policies/admin/content/text_block_policy.rb
+module Admin
+  module Content
+    class TextBlockPolicy < ::Admin::ApplicationPolicy
+    end
+  end
+end
+```
+
 ## Localization
 
 Godmin supports localization out of the box. For a list of translatable strings, [look here](https://github.com/varvet/godmin/blob/master/config/locales/en.yml).

--- a/lib/godmin/authorization.rb
+++ b/lib/godmin/authorization.rb
@@ -13,8 +13,42 @@ module Godmin
       end
     end
 
+    def policy(record)
+      policies[record] ||= Pundit.policy!(pundit_user, namespaced_record(record))
+    end
+
     def pundit_user
       admin_user
+    end
+
+    def namespaced_record(record)
+      return record unless engine_wrapper.namespaced?
+
+      class_name = find_class_name(record)
+      if already_namespaced?(class_name)
+        record
+      else
+        engine_wrapper.namespaced_path.map(&:to_sym) << record
+      end
+    end
+
+    # Borrowed from Pundit::PolicyFinder
+    def find_class_name(subject)
+      if subject.respond_to?(:model_name)
+        subject.model_name
+      elsif subject.class.respond_to?(:model_name)
+        subject.class.model_name
+      elsif subject.is_a?(Class)
+        subject
+      elsif subject.is_a?(Symbol)
+        subject.to_s.camelize
+      else
+        subject.class
+      end
+    end
+
+    def already_namespaced?(subject)
+      subject.to_s.start_with?("#{engine_wrapper.namespace.name}::")
     end
   end
 end

--- a/test/dummy/admin/app/controllers/admin/authorized_articles_controller.rb
+++ b/test/dummy/admin/app/controllers/admin/authorized_articles_controller.rb
@@ -8,6 +8,20 @@ module Admin
       "admin"
     end
 
+    def new
+      # The following calls to #policy are to check that the Authorization
+      # module can handle various different scenarios:
+      policy(Magazine).index?
+      policy(::Magazine).index?
+      policy(Magazine.new).index?
+      policy(Magazine.all).index?
+      policy(Admin::Magazine).index?
+      policy(Admin::Magazine.new).index?
+      policy(Admin::Magazine.where(name: "name")).index?
+
+      super
+    end
+
     def resource_service_class
       Admin::ArticleService
     end

--- a/test/dummy/admin/app/models/admin/magazine.rb
+++ b/test/dummy/admin/app/models/admin/magazine.rb
@@ -1,0 +1,4 @@
+module Admin
+  class Magazine < ::Magazine
+  end
+end

--- a/test/dummy/admin/app/policies/admin/article_policy.rb
+++ b/test/dummy/admin/app/policies/admin/article_policy.rb
@@ -3,5 +3,9 @@ module Admin
     def index?
       false
     end
+
+    def new?
+      true
+    end
   end
 end

--- a/test/dummy/admin/app/policies/admin/magazine_policy.rb
+++ b/test/dummy/admin/app/policies/admin/magazine_policy.rb
@@ -1,0 +1,4 @@
+module Admin
+  class MagazinePolicy < Godmin::Authorization::Policy
+  end
+end

--- a/test/dummy/admin/app/views/admin/shared/_navigation.html.erb
+++ b/test/dummy/admin/app/views/admin/shared/_navigation.html.erb
@@ -1,1 +1,6 @@
 <%= navbar_item Article %>
+<% if policy(Article).index? %>
+  Can index
+<% else %>
+  Can't index
+<% end %>

--- a/test/dummy/app/models/magazine.rb
+++ b/test/dummy/app/models/magazine.rb
@@ -1,0 +1,2 @@
+class Magazine < ActiveRecord::Base
+end

--- a/test/dummy/db/migrate/20210519215502_create_magazines.rb
+++ b/test/dummy/db/migrate/20210519215502_create_magazines.rb
@@ -1,0 +1,9 @@
+class CreateMagazines < ActiveRecord::Migration[6.1]
+  def change
+    create_table :magazines do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170207081043) do
+ActiveRecord::Schema.define(version: 2021_05_19_215502) do
 
   create_table "admin_users", force: :cascade do |t|
     t.string "email"
@@ -43,4 +43,11 @@ ActiveRecord::Schema.define(version: 20170207081043) do
     t.index ["article_id"], name: "index_comments_on_article_id"
   end
 
+  create_table "magazines", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  add_foreign_key "comments", "articles"
 end

--- a/test/generators/resource_generator_test.rb
+++ b/test/generators/resource_generator_test.rb
@@ -6,6 +6,7 @@ module Godmin
     tests ResourceGenerator
     destination File.expand_path("../../tmp", __FILE__)
     setup :prepare_destination
+    teardown :prepare_destination
 
     def test_resource_generator_in_standalone_install
       system "cd #{destination_root} && rails new . --skip-test --skip-spring --skip-bundle --skip-git --quiet"

--- a/test/integration/authorization_test.rb
+++ b/test/integration/authorization_test.rb
@@ -34,4 +34,12 @@ class AuthorizationTest < ActionDispatch::IntegrationTest
     visit admin.authorized_articles_path
     assert_equal 403, page.status_code
   end
+
+  def test_uses_engine_policy_in_engine?
+    visit admin.new_authorized_article_path
+
+    assert_equal 200, page.status_code
+
+    assert page.has_content?("Can't index"), "when used in an engine, the `policy` method is using the policy from the main app, not the engine"
+  end
 end


### PR DESCRIPTION
I believe this fixes a regression between Godmin 1.x and Godmin 2.x
regarding the engine installation: the previous behaviour was that Godmin
only looked for Policy classes in the main app.

In Godmin 2.0 controller actions correctly find the policy class in the
engine because the whole controller class is namespaced under the engine,
but direct calls to `policy` in views are not namespaced, so result in a
policy class from the main application being referenced, even if one exists
in the engine.

Background
========== 
The Godmin v1 we had the following logic:

    module Authorization
     ...

      def policy(record)
       policies[record] ||= PolicyFinder.find(record,
engine_wrapper.namespace).new(admin_user, record)
     end

      ...
   end

    module Authorization
     class PolicyFinder
       class << self
         def find(object, namespace = nil)
           klass = ...

            if namespace
             "#{namespace}::#{klass}Policy"
           else
             "#{klass}Policy"
           end.constantize
         end
       end
     end
   end

...and model classes were always referenced from the main application.

The effect of which was that when run as an engine, Godmin _always_ looked
for policy classes within the engine namespace.

Example: if the model was `Widget`, and the engine was called `Admin`, then
Godmin would look for `Admin::WidgetPolicy`, overriding any policy which
might exist in the main application

Regression
=========
When Godmin v2 was created and models were moved into the engine
(eg. Admin::Widget) this was mostly no longer necessary: Pundit mostly acts
on controller actions, and so are already nested under the engine's
namespace (eg. `Admin::WidgetsController`).

However, there are a number of ways in which direct calls to `policy` could
result in Godmin looking for policies in the main application.

Examples:

- `policy(::Widget)` within the `Admin` namespace
- `policy(Widget)` within a view (ie. not namespaced)
- `policy(Admin::Factory.widgets.first)` anywhere

Particularly with the last one, I don't think there's a way around this:
forcing the resulting `Widget` to be an instance of `Admin::Widget` instead
of `::Widget` feels like it would require a level of monkeypatching and/or
metaprogramming which I don't feel like we should be getting into.

Solution
======== 
The approach involves using the namespaced policies feature of
Pundit:

  https://github.com/varvet/pundit/tree/v2.1.0#policy-namespacing

https://github.com/varvet/pundit/blob/v2.1.0/lib/pundit/policy_finder.rb#L75-L78

We add the engine namespace on the front of the record before sending to
Pundit to find the policy. This has the effect of always looking for
policies in the engine namespace.

We then need to do some work to handle a number of cases:
- Where the record is already namespaced, because we're referring to the
 version of the model within the engine (eg. Admin::Widget)
- Where the record is already namespaced because it's part of another
 engine which is part of the admin site
- Where the record has the same initial string as the engine, but is not
 namespaced (eg. AdminNotification)

To be honest, this string matching on class namespaces feels like a bit of
a hack, but there doesn't seem to be a more idiomatic way to achieve the
result we're looking for.

Note: not all the cases are covered in tests - eg. odd edge cases where
there's an ActiveModel instance which has a `model_name` which is different
from the class name (?)

Impact
======
Now when using the Pundit mixins, or the `policy` method, Godmin
will only look for policies under the engine namespace.

Calls to `policy` will fail if there's a policy which only exists in the
main app, but I believe that's what we want: the admin engine is a separate
application which just happens to use the same model layer as the main
application.

Also I believe this was more or less the behaviour of Godmin 1, though it's
hard to be sure.

In complex admin applications where the admin application itself is split
up into multiple engines (eg. admin, admin-mailing, admin-users), these now
need to be namespaced under the same namespace as the engine
(ie. they must be eg. Admin::Content, rather than Content::Admin or some
other variation), or else all the policies need to live within the main
Godmin engine. This is because Godmin will now try to prepend the engine
namespace for all policy lookups unless the namespace is there already.

I believe that this change removes the necessity to have a class inside the
engine for every model, mirroring the models in the main app, but that can
be removed as a future change.