### PR TITLE
Fix: require pundit 2.0

### DIFF
--- a/godmin.gemspec
+++ b/godmin.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "csv_builder", "~> 2.1"
   gem.add_dependency "jquery-rails", [">= 4.0", "< 5.0"]
   gem.add_dependency "momentjs-rails", "~> 2.8"
-  gem.add_dependency "pundit", [">= 1.1", "< 2.0"]
+  gem.add_dependency "pundit", [">= 2.0.0", "< 3.0"]
   gem.add_dependency "rails", [">= 5.0", "< 7.0"]
   gem.add_dependency "sass-rails", [">= 5.0", "< 7.0"]
   gem.add_dependency "selectize-rails", "~> 0.12"


### PR DESCRIPTION
The namespacing feature we're using has a bug which was fixed in Pundit
2.0:

  https://github.com/varvet/pundit/pull/529

The namespace is required to look up the policy, but without this fix it
gets passed as the `record` in the policy, so the policy is trying to do
logic on an array like:

    [:admin, Widget]

...rather than on the actual record:

    Widget