### PR TITLE
Fix: column_value returns values

### DIFF
--- a/lib/godmin/helpers/tables.rb
+++ b/lib/godmin/helpers/tables.rb
@@ -33,7 +33,7 @@ module Godmin
             column_value = t(column_value.to_s)
           end
 
-          column_value
+          return column_value
         end
       end
     end


### PR DESCRIPTION
After releasing v2.2.0 and running godmin on Rails 5, column values no
longer rendered unless there was a partial or a function which governs
the behaviour of that column.

The issue seems to be that the partial_override block was always
returning nil, when in the default case (no partial is defined) it was
expected to return the column_value.

This is one of those "I don't know how this ever worked" problems: none
of the files involved seem to have been touched in years, and I'd be
surprised if this was a result of one of the Ruby or Rails upgrades
which were made on the project I experienced the issue on.

In any case, this seems to fix the issue, and columns with defined
partials also seem to work as expected.