### PR TITLE
Use latest env on travis to allow install of ruby3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 bundler_args: "--without debug"
 cache: bundler
 script: bundle exec rake test
+dist: focal
 rvm:
   - 2.6.7
   - 2.7.3


### PR DESCRIPTION
Issue described here:
https://github.com/rvm/rvm/issues/5133

On the default dist, we get:

    Could not download rvm-installer, please report to https://github.com/rvm/rvm/issues