### PR TITLE
Support (and require) pundit 2.2.0

### DIFF
--- a/godmin.gemspec
+++ b/godmin.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "csv_builder", "~> 2.1"
   gem.add_dependency "jquery-rails", [">= 4.0", "< 5.0"]
   gem.add_dependency "momentjs-rails", "~> 2.8"
-  gem.add_dependency "pundit", [">= 2.0.0", "< 3.0"]
+  gem.add_dependency "pundit", [">= 2.2.0", "< 3.0"]
   gem.add_dependency "rails", [">= 5.0", "< 7.0"]
   gem.add_dependency "sass-rails", [">= 5.0", "< 7.0"]
   gem.add_dependency "selectize-rails", "~> 0.12"

--- a/lib/godmin/authorization.rb
+++ b/lib/godmin/authorization.rb
@@ -5,7 +5,7 @@ module Godmin
   module Authorization
     extend ActiveSupport::Concern
 
-    include Pundit
+    include Pundit::Authorization
 
     included do
       rescue_from Pundit::NotAuthorizedError do


### PR DESCRIPTION
Running `include Pundit` using pundit 2.2.0 crashes when godmin is loaded, as the deprecation message about switching to `include Pundit::Authorization` is produced using `strip_heredoc` which is not yet loaded when the godmin gem is loaded.
