### PR TITLE
Add application.js if missing

### DIFF
--- a/lib/generators/godmin/install/install_generator.rb
+++ b/lib/generators/godmin/install/install_generator.rb
@@ -24,6 +24,8 @@ class Godmin::InstallGenerator < Godmin::Generators::Base
   def modify_application_js
     application_js = File.join("app/assets/javascripts", namespaced_path, "application.js")
 
+    create_file(application_js, "//= require_tree .") unless File.exists?(application_js)
+
     inject_into_file application_js, before: "//= require_tree ." do
       <<-END.strip_heredoc
         //= require moment


### PR DESCRIPTION
As mentioned in #252 rails 6+ doesn't generate the required javascript entry point for godmins install_generator. Below approach is likely an overly naive solution but should do the trick for projects running rails 6+. I've done some basic testing for both the Engine installation and standalone installations for latest versions of rails 6 and 7, and it seems to work.